### PR TITLE
Fix python >= 3.3 test_loader.py mock import

### DIFF
--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -16,9 +16,9 @@ except ImportError:
     import unittest
 
 try:
-    mock = unittest.mock
+    from unittest import mock
 
-except AttributeError:
+except ImportError:
 
     import mock
 


### PR DESCRIPTION
Python version: 3.6.5
Freshly cloned repo inside a virtualenv:
```pytb
$> PYTHONPATH=.:$PYTHONPATH python tests/unit/test_loader.py
Traceback (most recent call last):
  File "tests/unit/test_loader.py", line 19, in <module>
    mock = unittest.mock
AttributeError: module 'unittest' has no attribute 'mock'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "tests/unit/test_loader.py", line 23, in <module>
    import mock
ModuleNotFoundError: No module named 'mock'
```

`mock = unittest.mock` doesn't work because mock is not exposed in the unittest package (at least not before doing import unittest.mock). This PR does `from unittest import mock` instead.

I think the reason it doesn't fail on travis is because they pre-install mock: https://docs.travis-ci.com/user/reference/trusty/#Pre-installed-pip-packages and so despite the `mock = unittest.mock` not working, the `import mock` still does the job.