### PR TITLE
Add noescape option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 Revision 0.1.5, released XX-07-2018
 -----------------------------------
 
+- The `noescape` option implemented
 - Allow empty value syntax in the option-value pair e.g. `option: `
 
 Revision 0.1.4, released 27-05-2018

--- a/README.md
+++ b/README.md
@@ -329,7 +329,12 @@ on occurs in a config. Set to `False` to avoid such error messages.
 ### ccomments
 
 The parser will process C-style comments as well as hash-style comments. By default C-style comments are processed,
-you can disable that by setting *ccomments* option to `False.
+you can disable that by setting *ccomments* option to `False`.
+
+### noescape
+
+If you want to preserve escaping special characters ($\"#) in the configuration data, turn this parameter on. It is
+set to `False` by default.
 
 ## Parser plugins
 
@@ -414,7 +419,8 @@ usage: apacheconfigtool [-h] [-v] [--allowmultioptions] [--forcearray]
                         [--mergeduplicateblocks] [--mergeduplicateoptions]
                         [--autotrue] [--interpolatevars] [--interpolateenv]
                         [--allowsinglequoteinterpolation] [--strictvars]
-                        [--ccomments]
+                        [--noescape] [--ccomments] [--configpath CONFIGPATH]
+                        [--flagbits <JSON>] [--defaultconfig <JSON>]
                         file [file ...]
 
 Dump Apache config files into JSON

--- a/apacheconfig/apacheconfigtool.py
+++ b/apacheconfig/apacheconfigtool.py
@@ -110,6 +110,11 @@ def main():
     )
 
     options.add_argument(
+        '--noescape', action='store_true',
+        help='Preserve special escape characters left outs in the configuration values'
+    )
+
+    options.add_argument(
         '--ccomments', action='store_false',
         help='Do not parse C-style comments'
     )

--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -128,6 +128,19 @@ class ApacheConfigLoader(object):
                     else:
                         statements[option] = interpolate(value)
 
+        def remove_escapes(value):
+            if self._options.get('noescape'):
+                return value
+            if not isinstance(value, str):
+                return value
+            return re.sub(r'\\([$\\"#])', lambda x: x.groups()[0], value)
+
+        for option, value in tuple(statements.items()):
+            if isinstance(value, list):
+                statements[option] = [remove_escapes(x) for x in value]
+            else:
+                statements[option] = remove_escapes(value)
+
         self._stack.insert(0, statements)
 
         return statements

--- a/tests/integration/test_perl_samples.py
+++ b/tests/integration/test_perl_samples.py
@@ -40,7 +40,7 @@ test_configs = {
                                        'quoted': 'this one contains whitespace at the end    ',
                                        'passwd': 'sakkra',
                                        'db': {'host': 'blah.blubber'},
-                                       'quotedwithquotes': ' holy crap, it contains \\"masked quotes\\" and '
+                                       'quotedwithquotes': ' holy crap, it contains "masked quotes" and '
                                                            '\'single quotes\'  ',
                                        'cops': {'officer':
                                                     [{'randall': {'age': '25', 'name': 'stein'}},

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -240,6 +240,36 @@ mode = CLEAR | UNSECURE
 
         self.assertEqual(config, {'mode': {'CLEAR': 1, 'STRONG': None, 'UNSECURE': '32bit'}})
 
+    def testEscape(self):
+        text = """\
+a = \\$b
+"""
+        ApacheConfigLexer = make_lexer()
+        ApacheConfigParser = make_parser()
+
+        loader = ApacheConfigLoader(ApacheConfigParser(ApacheConfigLexer()))
+
+        config = loader.loads(text)
+
+        self.assertEqual(config, {'a': '$b'})
+
+    def testNoEscape(self):
+        text = """\
+a = \\$b
+"""
+        options = {
+            'noescape': True
+        }
+
+        ApacheConfigLexer = make_lexer(**options)
+        ApacheConfigParser = make_parser(**options)
+
+        loader = ApacheConfigLoader(ApacheConfigParser(ApacheConfigLexer()), **options)
+
+        config = loader.loads(text)
+
+        self.assertEqual(config, {'a': '\\$b'})
+
     @mock.patch('os.path.exists')
     def testConfigPath(self, path_exists_mock):
         text = """\


### PR DESCRIPTION
The `no escape` option can be used to [preserve the leftovers of special escape chars](https://metacpan.org/source/TLINDEN/Config-General-2.63/General.pm#L1216) in the values. This hopefully addresses issue #6 .