### PR TITLE
Allow empty value syntax in the option-value pair

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,9 @@
 
+Revision 0.1.5, released XX-07-2018
+-----------------------------------
+
+- Allow empty value syntax in the option-value pair e.g. `option: `
+
 Revision 0.1.4, released 27-05-2018
 -----------------------------------
 

--- a/apacheconfig/__init__.py
+++ b/apacheconfig/__init__.py
@@ -1,5 +1,5 @@
 # http://www.python.org/dev/peps/pep-0396/
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 from contextlib import contextmanager
 

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -154,12 +154,13 @@ class BaseApacheConfigLexer(object):
         if not re.match(r'.*?[ \n\r\t=]+', token):
             raise ApacheConfigError('Syntax error in option-value pair %s' % token)
         option, value = re.split(r'[ \n\r\t=]+', token, maxsplit=1)
-        if not option or not value:
+        if not option:
             raise ApacheConfigError('Syntax error in option-value pair %s' % token)
-        if value[0] == '"' and value[-1] == '"':
-            value = DoubleQuotedString(value[1:-1])
-        if value[0] == "'" and value[-1] == "'":
-            value = SingleQuotedString(value[1:-1])
+        if value:
+            if value[0] == '"' and value[-1] == '"':
+                value = DoubleQuotedString(value[1:-1])
+            if value[0] == "'" and value[-1] == "'":
+                value = SingleQuotedString(value[1:-1])
         if '#' in value:
             value = value.replace('\\#', '#')
         return option, value
@@ -173,7 +174,7 @@ class BaseApacheConfigLexer(object):
             return True, option, value
 
     def t_OPTION_AND_VALUE(self, t):
-        r'[^ \n\r\t=]+[ \n\r\t=]+[^\r\n]+'
+        r'[^ \n\r\t=]+[ =]*[\n\r]+|[^ \n\r\t=]+[ \n\r\t=]+[^\r\n]+'
         if t.value.endswith('\\'):
             t.lexer.code_start = t.lexer.lexpos - len(t.value)
             t.lexer.begin('multiline')

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -26,6 +26,7 @@ class LexerTestCase(unittest.TestCase):
 
     def testOptionAndValueSet(self):
         text = """\
+a 
 a b
 a = b
 a    b
@@ -36,7 +37,7 @@ a "b"
 a = "b"
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, [('a', 'b'), ('a', 'b'), ('a', 'b'),
+        self.assertEqual(tokens, [('a', ''), ('a', 'b'), ('a', 'b'), ('a', 'b'),
                                   ('a', 'b'), ('a', 'b'), ('a', 'b'),
                                   ('a', 'b'), ('a', 'b')])
 

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -62,10 +62,10 @@ class ParserTestCase(unittest.TestCase):
 
     def testCStyleCommentsDisabled(self):
             text = """\
-    /*a*/
-    /*
-    # b
-    */
+/*a*/
+/*
+# b
+*/
         """
             options = {
                 'ccomments': False
@@ -76,7 +76,13 @@ class ParserTestCase(unittest.TestCase):
 
             parser = ApacheConfigParser(ApacheConfigLexer(), start='contents')
 
-            self.assertRaises(ApacheConfigError, parser.parse, text)
+            ast = parser.parse(text)
+
+            # C comments parsed as statements
+            self.assertEqual(ast, ['contents',
+                                   ['statements', ['statement', '/*a*/', ''], ['statement', '/*', '']],
+                                   ['comment', ' b'],
+                                   ['statements', ['statement', '*/', '']]])
 
     def testIncludes(self):
         text = """\


### PR DESCRIPTION
To address issue https://github.com/etingof/apacheconfig/issues/8