### PR TITLE
Right-strips trailing spaces by default and adds an option to disable it

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Will result in a single value array entry if the *forcearray* option is turned o
 If set to `True`, then all options found in the config will be converted to lowercase. This allows you to
 provide case-in-sensitive configs. The values of the options will not lowercased.
 
+### nostripvalues
+
+If set to `False`, then each value found in the config will not be right-stripped. This allows you to gather the options as long as their trailing whitespaces.
+
 ### useapacheinclude
 
 If set to `True`, the parser will consider "include ..." as valid include statement (just like the well known
@@ -431,15 +435,17 @@ options.
 
 ```bash
 $ apacheconfigtool  --help
-usage: apacheconfigtool [-h] [-v] [--allowmultioptions] [--forcearray]
-                        [--lowercasenames] [--useapacheinclude]
-                        [--includeagain] [--includerelative]
-                        [--includedirectories] [--includeglob]
-                        [--mergeduplicateblocks] [--mergeduplicateoptions]
-                        [--autotrue] [--interpolatevars] [--interpolateenv]
+usage: apacheconfigtool [-h] [-v] [--json-input] [--allowmultioptions]
+                        [--forcearray] [--lowercasenames] [--nostripvalues]
+                        [--useapacheinclude] [--includeagain]
+                        [--includerelative] [--includedirectories]
+                        [--includeglob] [--mergeduplicateblocks]
+                        [--mergeduplicateoptions] [--autotrue]
+                        [--interpolatevars] [--interpolateenv]
                         [--allowsinglequoteinterpolation] [--strictvars]
-                        [--noescape] [--ccomments] [--configpath CONFIGPATH]
-                        [--flagbits <JSON>] [--defaultconfig <JSON>]
+                        [--noescape] [--ccomments]
+                        [--configpath CONFIGPATH] [--flagbits <JSON>]
+                        [--defaultconfig <JSON>]
                         file [file ...]
 
 Dump Apache config files into JSON
@@ -450,6 +456,8 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
+  --json-input          Expect JSON file(s) on input, produce Apache
+                        configuration
 
 parsing options:
   --allowmultioptions   Collect multiple identical options into a list
@@ -458,6 +466,8 @@ parsing options:
                         of the config entry by []
   --lowercasenames      All options found in the config will be converted to
                         lowercase
+  --nostripvalues       All values found in the config will not be right-
+                        stripped
   --useapacheinclude    Consider "include ..." as valid include statement
   --includeagain        Allow including sub-configfiles multiple times
   --includerelative     Open included config files from within the location of
@@ -484,6 +494,8 @@ parsing options:
                         single quotes
   --strictvars          Do not fail on an undefined variable when performing
                         interpolation
+  --noescape            Preserve special escape characters left outs in the
+                        configuration values
   --ccomments           Do not parse C-style comments
   --configpath CONFIGPATH
                         Search path for the configuration files being

--- a/apacheconfig/apacheconfigtool.py
+++ b/apacheconfig/apacheconfigtool.py
@@ -50,6 +50,11 @@ def main():
     )
 
     options.add_argument(
+        '--nostripvalues', action='store_true',
+        help='All values found in the config will not be right-stripped'
+    )
+
+    options.add_argument(
         '--useapacheinclude', action='store_true',
         help='Consider "include ..." as valid include statement'
     )

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -83,6 +83,9 @@ class BaseApacheConfigParser(object):
         if self.options.get('lowercasenames'):
             p[0][1] = p[0][1].lower()
 
+        if not self.options.get('nostripvalues', False):
+            p[0][2] = p[0][2].rstrip()
+
     def p_statements(self, p):
         """statements : statements statement
                       | statement

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -225,17 +225,42 @@ a = "b"
                                  ['statements', ['statement', 'bb', 'Cc']]],
                                 'aa']])
 
+    def testNoStripValues(self):
+        text = """\
+    <aA>
+      Bb Cc   \
+
+    </aA>
+"""
+        options = {
+            'nostripvalues': True
+        }
+
+        ApacheConfigLexer = make_lexer(**options)
+        ApacheConfigParser = make_parser(**options)
+
+        parser = ApacheConfigParser(ApacheConfigLexer(), start='contents')
+
+        ast = parser.parse(text)
+        self.assertEqual(ast, ['contents',
+                               ['block', 'aA',
+                                ['contents',
+                                 ['statements', ['statement', 'Bb', 'Cc   ']]],
+                                'aA']])
+
     def testWholeConfig(self):
         text = """\
 # a
 a = b
 
 <a>
-  a = b
+  a = b  \
+
 </a>
 a b
  <a a>
-  a b
+  a b  \
+
  </a a>
 # a
 """


### PR DESCRIPTION
Hey ! Today it's a PR coming from us :tada:

I banged my head another time before realizing the parser actually didn't stripped useless trailing white-spaces for values.
Maybe a side-effect of a previous commit ?
It looks like this feature was not tested either.

Anyway, here we are, I let you take a look to the changes and keep me posted :ok_hand:

Bye :wave: 

(Ofc feel free to edit my branch directly if you want)

PS : The `\` added are for Python linters, we could remove them if you want too.