### PR TITLE
return clearer error message

### DIFF
--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -145,7 +145,7 @@ class BaseApacheConfigParser(object):
             p[0] = ['config', p[1]]
 
     def p_error(self, p):
-        raise ApacheConfigError("Parser error at '%s'" % p.value if p else 'Unexpected eof')
+        raise ApacheConfigError("Parser error at '%s'" % p.value if p else 'Unexpected EOF')
 
 
 def make_parser(**options):

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -145,7 +145,7 @@ class BaseApacheConfigParser(object):
             p[0] = ['config', p[1]]
 
     def p_error(self, p):
-        raise ApacheConfigError("Parser error at '%s'" % p.value if p else '?')
+        raise ApacheConfigError("Parser error at '%s'" % p.value if p else 'Unexpected eof')
 
 
 def make_parser(**options):


### PR DESCRIPTION
The ply parser calls `p_error` with `None` if the syntax error is due to reaching the `end-of-file`.