### PR TITLE
Fixed quoting issue for includes

### DIFF
--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -205,7 +205,7 @@ class ApacheConfigLoader(object):
             return {}
 
     def g_include(self, ast):
-        filepath = ast[0]
+        filepath = self._unquote_tag(ast[0])
 
         options = self._options
 


### PR DESCRIPTION
Hello,

here is trivial fix which handle config format like this
```
        Include "conf/marketing_data_list.conf"
        Include "conf/ip_database.conf"
```

P.S. I not completely understand why you using your own `_unquote_tag` function instead `.strip("\"\'")`