### PR TITLE
Combine merging logic to simplify BNF

### DIFF
--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -94,36 +94,17 @@ class ApacheConfigLoader(object):
 
         return contents
 
-    def g_statements(self, ast):
-        statements = {}
-
-        for subtree in ast:
-            items = self._walkast(subtree)
-            for item in items:
-                if item in statements:
-                    if (self._options.get('allowmultioptions', True) and
-                            not self._options.get('mergeduplicateoptions', False)):
-                        if not isinstance(statements[item], list):
-                            statements[item] = [statements[item]]
-                        statements[item].append(items[item])
-                    elif self._options.get('mergeduplicateoptions', False):
-                        statements[item] = items[item]
-                    else:
-                        raise error.ApacheConfigError('Duplicate option "%s" prohibited' % item)
-                else:
-                    statements[item] = items[item]
-
+    def _interpolate_vars(self, option, value):
+        """Store option / values in `stack` and interpolate value when referenced.
+        Returns `value` with any interpolated variables.
+        """
         if (self._options.get('interpolateenv', False) or
                 self._options.get('allowsinglequoteinterpolation', False)):
             self._options['interpolatevars'] = True
 
         if self._options.get('interpolatevars', False):
-
             def lookup(match):
                 option = match.groups()[0]
-
-                if option in statements:
-                    return interpolate(statements[option])
 
                 for frame in self._stack:
                     if option in frame:
@@ -144,20 +125,32 @@ class ApacheConfigLoader(object):
                     return expanded
                 return re.sub(r'(?<!\\)\$([^\n\r $]+?)', lookup, value)
 
-            for option, value in tuple(statements.items()):
-                if (not getattr(value, 'is_single_quoted', False) or
-                        self._options.get('allowsinglequoteinterpolation', False)):
-                    if isinstance(value, list):
-                        statements[option] = [interpolate(x) for x in value]
-                    else:
-                        statements[option] = interpolate(value)
+            if (not getattr(value, 'is_single_quoted', False) or
+                    self._options.get('allowsinglequoteinterpolation', False)):
+                if isinstance(value, list):
+                    value = [interpolate(x) for x in value]
+                else:
+                    value = interpolate(value)
 
-        self._stack.insert(0, statements)
-
-        return statements
+        self._stack.insert(0, {option: value})
+        return value
 
     def g_statement(self, ast):
+        """Performs postprocessing on a statement. Returns an {option: value} dict.
+        """
         option, value = ast[:2]
+        value = self._interpolate_vars(option, value)
+
+        def remove_escapes(value):
+            if self._options.get('noescape'):
+                return value
+            if not isinstance(value, str):
+                return value
+            return re.sub(r'\\([$\\"#])', lambda x: x.groups()[0], value)
+        if isinstance(value, list):
+            value = [remove_escapes(x) for x in value]
+        else:
+            value = remove_escapes(value)
 
         flagbits = self._options.get('flagbits')
         if flagbits and option in flagbits:
@@ -176,18 +169,6 @@ class ApacheConfigLoader(object):
         if self._options.get('forcearray'):
             if value.startswith('[') and value.endswith(']'):
                 value = [value[1:-1]]
-
-        def remove_escapes(value):
-            if self._options.get('noescape'):
-                return value
-            if not isinstance(value, str):
-                return value
-            return re.sub(r'\\([$\\"#])', lambda x: x.groups()[0], value)
-
-        if isinstance(value, list):
-            value = [remove_escapes(x) for x in value]
-        else:
-            value = remove_escapes(value)
 
         return {
             option: value
@@ -260,47 +241,50 @@ class ApacheConfigLoader(object):
             raise error.ConfigFileReadError('Config file "%s" not found in search path %s' % (filename, ':'.join(configpath)))
 
     def _merge_contents(self, contents, items):
+        """Merges items into existing contents dictionary.
+        Returns new contents.
+        """
         for item in items:
-            # In case of duplicate keys, AST can contain a list of values.
-            # Here all values forced into being a list to unify further processing.
-            if isinstance(items[item], list):
-                vector = items[item]
-            else:
-                vector = [items[item]]
+            contents = self._merge_item(contents, item, items[item])
+        return contents
 
-            if item in contents:
-                # TODO(etingof): keep block/statements merging at one place
-                if self._options.get('mergeduplicateblocks'):
-                    contents = self._merge_dicts(contents, items)
-                else:
-                    if not isinstance(contents[item], list):
-                        contents[item] = [contents[item]]
-                    contents[item].extend(vector)
-            else:
-                contents[item] = items[item]
+    def _merge_item(self, contents, key, value, path=[]):
+        """Merges a single "key, value" item into contents dictionary, and returns new contents.
+        Merging rules differ depending on flags set, and whether `value` is a dictionary (block).
+        """
+        if key not in contents:
+            contents[key] = value
+            return contents
 
+        # In case of duplicate keys, AST can contain a list of values.
+        # Here all values forced into being a list to unify further processing.
+        if isinstance(value, list):
+            vector = value
+        else:
+            vector = [value]
+
+        if isinstance(value, dict): # Merge block into contents
+            if self._options.get('mergeduplicateblocks'):
+                contents = self._merge_dicts(contents[key], value)
+            else:
+                if not isinstance(contents[key], list):
+                    contents[key] = [contents[key]]
+                contents[key] += vector
+        else: # Merge statement/option into contents
+            if not self._options.get('allowmultioptions', True) and not self._options.get('mergeduplicateoptions', False):
+                raise error.ApacheConfigError('Duplicate option "%s" prohibited' % '.'.join(path + [str(key)]))
+            if self._options.get('mergeduplicateoptions', False):
+                contents[key] = value
+            else:
+                if not isinstance(contents[key], list):
+                    contents[key] = [contents[key]]
+                contents[key] += vector
         return contents
 
     def _merge_dicts(self, dict1, dict2, path=[]):
-        "merges dict2 into dict1"
+        """Merges items from dict2 into dict1."""
         for key in dict2:
-            if key in dict1:
-                if isinstance(dict1[key], dict) and isinstance(dict2[key], dict):
-                    self._merge_dicts(dict1[key], dict2[key], path + [str(key)])
-                elif dict1[key] != dict2[key]:
-                    if self._options.get('allowmultioptions', True):
-                        if not isinstance(dict1[key], list):
-                            dict1[key] = [dict1[key]]
-                        if not isinstance(dict2[key], list):
-                            dict2[key] = [dict2[key]]
-                        dict1[key] = self._merge_lists(dict1[key], dict2[key])
-                    else:
-                        if self._options.get('mergeduplicateoptions', False):
-                            dict1[key] = dict2[key]
-                        else:
-                            raise error.ApacheConfigError('Duplicate option "%s" prohibited' % '.'.join(path + [str(key)]))
-            else:
-                dict1[key] = dict2[key]
+            dict1 = self._merge_item(dict1, key, dict2[key], path)
         return dict1
 
     def _merge_lists(self, list1, list2):

--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -152,19 +152,6 @@ class ApacheConfigLoader(object):
                     else:
                         statements[option] = interpolate(value)
 
-        def remove_escapes(value):
-            if self._options.get('noescape'):
-                return value
-            if not isinstance(value, str):
-                return value
-            return re.sub(r'\\([$\\"#])', lambda x: x.groups()[0], value)
-
-        for option, value in tuple(statements.items()):
-            if isinstance(value, list):
-                statements[option] = [remove_escapes(x) for x in value]
-            else:
-                statements[option] = remove_escapes(value)
-
         self._stack.insert(0, statements)
 
         return statements
@@ -189,6 +176,18 @@ class ApacheConfigLoader(object):
         if self._options.get('forcearray'):
             if value.startswith('[') and value.endswith(']'):
                 value = [value[1:-1]]
+
+        def remove_escapes(value):
+            if self._options.get('noescape'):
+                return value
+            if not isinstance(value, str):
+                return value
+            return re.sub(r'\\([$\\"#])', lambda x: x.groups()[0], value)
+
+        if isinstance(value, list):
+            value = [remove_escapes(x) for x in value]
+        else:
+            value = remove_escapes(value)
 
         return {
             option: value

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -89,27 +89,18 @@ class BaseApacheConfigParser(object):
                 not hasattr(p[0][2], 'is_double_quoted')):
             p[0][2] = p[0][2].rstrip()
 
-    def p_statements(self, p):
-        """statements : statements statement
-                      | statement
+    def p_item(self, p):
+        """item : statement
+                | comment
+                | include
+                | includeoptional
+                | block
         """
-        n = len(p)
-        if n == 3:
-            p[0] = p[1] + [p[2]]
-        elif n == 2:
-            p[0] = ['statements', p[1]]
+        p[0] = p[1:][0]
 
     def p_contents(self, p):
-        """contents : contents statements
-                    | contents comment
-                    | contents include
-                    | contents includeoptional
-                    | contents block
-                    | statements
-                    | comment
-                    | include
-                    | includeoptional
-                    | block
+        """contents : contents item
+                    | item
         """
         n = len(p)
         if n == 3:

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -92,7 +92,6 @@ a b
 
         self.assertEqual(expect_text, gen_text)
 
-
     def testForceArray(self):
         text = """\
 b = [1]
@@ -218,6 +217,7 @@ a = 3
     def testDuplicateOptionsDenied(self):
         text = """\
 a = 1
+<b/>
 a = 2
 """
         options = {
@@ -259,7 +259,7 @@ b = 2
                 'b': '4',
                 'c': '3'
             },
-            'mergeduplicateoptions': True
+            'mergeduplicateoptions': False
         }
 
         ApacheConfigLexer = make_lexer(**options)

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -48,9 +48,9 @@ c \# # c
             self.assertEqual(ast, ['contents',
                                    ['comment', 'a'],
                                    ['comment', ' b'],
-                                   ['statements', ['statement', 'c', 'c']],
+                                   ['statement', 'c', 'c'],
                                    ['comment', ' c'],
-                                   ['statements', ['statement', 'c', '# # c']]])
+                                   ['statement', 'c', '# # c']])
 
     def testCStyleComments(self):
         text = """\
@@ -130,10 +130,10 @@ a "b"
         ApacheConfigLexer = make_lexer()
         ApacheConfigParser = make_parser()
 
-        parser = ApacheConfigParser(ApacheConfigLexer(), start='statements')
+        parser = ApacheConfigParser(ApacheConfigLexer(), start='contents')
 
         ast = parser.parse(text)
-        self.assertEqual(ast, ['statements',
+        self.assertEqual(ast, ['contents',
                                ['statement', 'a', 'b'],
                                ['statement', 'a', 'b'],
                                ['statement', 'a', 'b'],
@@ -162,11 +162,9 @@ a "b"
         self.assertEqual(ast, ['block', 'a',
                                ['contents',
                                 ['comment', 'a'],
-                                ['statements',
-                                 ['statement', 'a', 'b b']],
+                                 ['statement', 'a', 'b b'],
                                 ['comment', ' a b'],
-                                ['statements',
-                                 ['statement', 'a', 'b b']]], 'a'])
+                                 ['statement', 'a', 'b b']], 'a'])
 
     def testNestedBlock(self):
             text = """\
@@ -241,7 +239,7 @@ a "b"
                                ['block', 'a', [], 'a'],
                                ['block', 'aa',
                                 ['contents',
-                                 ['statements', ['statement', 'bb', 'Cc']]],
+                                 ['statement', 'bb', 'Cc']],
                                 'aa']])
 
     def testNoStripValues(self):
@@ -264,7 +262,7 @@ a "b"
         self.assertEqual(ast, ['contents',
                                ['block', 'aA',
                                 ['contents',
-                                 ['statements', ['statement', 'Bb', 'Cc   ']]],
+                                 ['statement', 'Bb', 'Cc   ']],
                                 'aA']])
 
     def testHereDoc(self):
@@ -287,10 +285,8 @@ a "b"
         self.assertEqual(ast, ['contents',
                                ['block', 'main',
                                 ['contents',
-                                 ['statements',
-                                  ['statement',
-                                   'PYTHON', '        def a():\n            x = y\n            return'
-                                   ]
+                                 ['statement',
+                                  'PYTHON', '        def a():\n            x = y\n            return'
                                   ]
                                  ],
                                 'main']])
@@ -323,16 +319,15 @@ a b
             'config',
             ['contents',
                 ['comment', ' a'],
-                ['statements', ['statement', 'a', 'b']],
+                ['statement', 'a', 'b'],
                 ['block', 'a',
-                 ['contents', ['statements', ['statement', 'a', 'b']]],
+                 ['contents', ['statement', 'a', 'b']],
                  'a'],
-                ['statements', ['statement', 'a', 'b']],
+                ['statement', 'a', 'b'],
                 ['block', 'a a',
                  ['contents',
-                  ['statements',
-                   ['statement', 'a', 'b'],
-                   ['statement', 'c', 'd']],
+                  ['statement', 'a', 'b'],
+                  ['statement', 'c', 'd'],
                   ['comment', ' c']],
                  'a a'],
                 ['comment', ' a']]


### PR DESCRIPTION
To make the whitespace-preserving PR a bit easier to parse, we need to refactor and simplify the BNF a bit. Here's the parts that are not related to the whitespace PR. In particular, we remove the `statements` object and consolidated some of the the routines in `loader.py`.

Most of this is moving code around-- the new bits primarily involve combining parts of the merging logic from across `merge_contents`, `merge_statements`, and `merge_dicts` into `merge_item`.

I'm not quite familiar with the `Config::General` flags, but the purpose of `merge_lists` and much of the existing `merge_dicts` implementation wasn't entirely clear to me, so even though the existing tests continued to pass, there may be some use case I'm missing here.

Fixes #44.