### PR TITLE
Lint cleanup and add flake8 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,12 @@ matrix:
     dist: trusty
     python: 'pypy3'
 install:
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then pip install flake8; fi
   - pip install codecov
-  - pip install flake8
   - pip install -r requirements.txt -r test-requirements.txt
   - pip install -e .
 script:
-  - flake8 ./apacheconfig
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then flake8 ./apacheconfig; fi
   - PYTHONPATH=.:$PYTHONPATH python tests/__main__.py
 after_success:
   - PYTHONPATH=.:$PYTHONPATH coverage run --omit=*test* tests/__main__.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,11 @@ matrix:
     python: 'pypy3'
 install:
   - pip install codecov
+  - pip install flake8
   - pip install -r requirements.txt -r test-requirements.txt
   - pip install -e .
 script:
+  - flake8 ./apacheconfig
   - PYTHONPATH=.:$PYTHONPATH python tests/__main__.py
 after_success:
   - PYTHONPATH=.:$PYTHONPATH coverage run --omit=*test* tests/__main__.py

--- a/apacheconfig/__init__.py
+++ b/apacheconfig/__init__.py
@@ -14,4 +14,9 @@ def make_loader(**options):
     ApacheConfigLexer = make_lexer(**options)
     ApacheConfigParser = make_parser(**options)
 
-    yield ApacheConfigLoader(ApacheConfigParser(ApacheConfigLexer()), **options)
+    yield ApacheConfigLoader(ApacheConfigParser(ApacheConfigLexer()),
+                             **options)
+
+
+__all__ = ['make_lexer', 'make_parser', 'make_loader', 'ApacheConfigLoader',
+           'ApacheConfigError']

--- a/apacheconfig/apacheconfigtool.py
+++ b/apacheconfig/apacheconfigtool.py
@@ -9,13 +9,14 @@ import sys
 import os
 import json
 
-from apacheconfig import *
+from apacheconfig import make_loader, ApacheConfigError
 from apacheconfig import __version__
 
 
 def main():
 
-    parser = argparse.ArgumentParser(description='Dump Apache config files into JSON')
+    parser = argparse.ArgumentParser(
+                description='Dump Apache config files into JSON')
 
     parser.add_argument(
         '-v', '--version', action='version', version='%(prog)s ' + __version__
@@ -40,8 +41,9 @@ def main():
 
     options.add_argument(
         '--forcearray', action='store_true',
-        help=('Force a single config line to get parsed into a list by turning '
-              'on this option and by surrounding the value of the config entry by []')
+        help=('Force a single config line to get parsed into a list by '
+              'turning on this option and by surrounding the value of the '
+              'config entry by []')
     )
 
     options.add_argument(
@@ -121,12 +123,14 @@ def main():
 
     options.add_argument(
         '--strictvars', action='store_false',
-        help='Do not fail on an undefined variable when performing interpolation'
+        help=('Do not fail on an undefined variable when performing '
+              'interpolation')
     )
 
     options.add_argument(
         '--noescape', action='store_true',
-        help='Preserve special escape characters left outs in the configuration values'
+        help=('Preserve special escape characters left outs in the '
+              'configuration values')
     )
 
     options.add_argument(
@@ -136,12 +140,14 @@ def main():
 
     options.add_argument(
         '--configpath', action='append', default=[],
-        help='Search path for the configuration files being included. Can repeat.'
+        help=('Search path for the configuration files being included. Can '
+              'repeat.')
     )
 
     options.add_argument(
         '--flagbits', metavar='<JSON>', type=str,
-        help='Named bits for an option in form of a JSON object of the following structure {"OPTION": {"NAME": "VALUE"}}'
+        help=('Named bits for an option in form of a JSON object of the '
+              'following structure {"OPTION": {"NAME": "VALUE"}}')
     )
 
     options.add_argument(
@@ -152,7 +158,8 @@ def main():
     args = parser.parse_args()
 
     options = dict([(option, getattr(args, option)) for option in dir(args)
-                    if not option.startswith('_') and getattr(args, option) is not None])
+                    if not option.startswith('_') and
+                    getattr(args, option) is not None])
 
     options['programpath'] = os.path.dirname(sys.argv[0])
 
@@ -161,7 +168,8 @@ def main():
             options['flagbits'] = json.loads(options['flagbits'])
 
         except Exception as ex:
-            sys.stderr.write('Malformed flagbits %s: %s\n' % (options['flagbits'], ex))
+            sys.stderr.write('Malformed flagbits %s: %s\n' %
+                             (options['flagbits'], ex))
             return 1
 
     if 'defaultconfig' in options:
@@ -169,7 +177,8 @@ def main():
             options['defaultconfig'] = json.loads(options['defaultconfig'])
 
         except Exception as ex:
-            sys.stderr.write('Malformed defaultconfig %s: %s\n' % (options['defaultconfig'], ex))
+            sys.stderr.write('Malformed defaultconfig %s: %s\n' %
+                             (options['defaultconfig'], ex))
             return 1
 
     if args.json_input:
@@ -182,7 +191,8 @@ def main():
                         sys.stdout.write(loader.dumps(json.load(f)))
 
                 except Exception as ex:
-                    sys.stderr.write('Failed to dump JSON document %s into Apache config: %s\n' % (json_file, ex))
+                    sys.stderr.write(('Failed to dump JSON document %s into '
+                                      'Apache config: %s\n') % (json_file, ex))
                     return 1
 
     else:
@@ -197,7 +207,8 @@ def main():
                     config = loader.load(config_file)
 
                 except ApacheConfigError as ex:
-                    sys.stderr.write('Failed to parse Apache config %s: %s\n' % (config_file, ex))
+                    sys.stderr.write('Failed to parse Apache config %s: %s\n'
+                                     % (config_file, ex))
                     return 1
 
                 sys.stdout.write(json.dumps(config, indent=2) + '\n')

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -58,7 +58,8 @@ class CStyleCommentsLexer(object):
         t.lexer.ccomment_level -= 1
 
         if t.lexer.ccomment_level == 0:
-            t.value = t.lexer.lexdata[t.lexer.code_start:t.lexer.lexpos + 1 - 3]
+            t.value = t.lexer.lexdata[t.lexer.code_start:
+                                      t.lexer.lexpos + 1 - 3]
             t.type = "CCOMMENT"
             t.lexer.lineno += t.value.count('\n')
             t.lexer.begin('INITIAL')
@@ -68,7 +69,8 @@ class CStyleCommentsLexer(object):
         r'.+?'
 
     def t_ccomment_error(self, t):
-        raise ApacheConfigError("Illegal character '%s' in C-style comment" % t.value[0])
+        raise ApacheConfigError("Illegal character '%s' in C-style comment"
+                                % t.value[0])
 
 
 class ApacheIncludesLexer(object):
@@ -256,7 +258,8 @@ class BaseApacheConfigLexer(object):
         t.type = "OPTION_AND_VALUE"
         t.lexer.begin('INITIAL')
 
-        value = t.lexer.lexdata[t.lexer.code_start + 1:t.lexer.lexpos - len(t.lexer.heredoc_anchor)]
+        value = t.lexer.lexdata[t.lexer.code_start + 1:
+                                t.lexer.lexpos - len(t.lexer.heredoc_anchor)]
 
         t.lexer.lineno += len(re.findall(r'\r\n|\n|\r', t.value))
 
@@ -292,22 +295,28 @@ def make_lexer(**options):
 
     lexer_class = type('ApacheConfigLexer',
                        (lexer_class, HashCommentsLexer),
-                       {'tokens': lexer_class.tokens + HashCommentsLexer.tokens,
-                        'states': lexer_class.states + HashCommentsLexer.states,
+                       {'tokens': lexer_class.tokens +
+                        HashCommentsLexer.tokens,
+                        'states': lexer_class.states +
+                        HashCommentsLexer.states,
                         'options': options})
 
     if options.get('ccomments', True):
         lexer_class = type('ApacheConfigLexer',
                            (lexer_class, CStyleCommentsLexer),
-                           {'tokens': lexer_class.tokens + CStyleCommentsLexer.tokens,
-                            'states': lexer_class.states + CStyleCommentsLexer.states,
+                           {'tokens': lexer_class.tokens +
+                            CStyleCommentsLexer.tokens,
+                            'states': lexer_class.states +
+                            CStyleCommentsLexer.states,
                             'options': options})
 
     if options.get('useapacheinclude', True):
         lexer_class = type('ApacheConfigLexer',
                            (lexer_class, ApacheIncludesLexer),
-                           {'tokens': lexer_class.tokens + ApacheIncludesLexer.tokens,
-                            'states': lexer_class.states + ApacheIncludesLexer.states,
+                           {'tokens': lexer_class.tokens +
+                            ApacheIncludesLexer.tokens,
+                            'states': lexer_class.states +
+                            ApacheIncludesLexer.states,
                             'options': options})
 
     return lexer_class

--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -85,7 +85,8 @@ class ApacheConfigLoader(object):
         return block
 
     def g_contents(self, ast):
-        # TODO(etingof): remove defaulted and overridden options from productions
+        # TODO(etingof): remove defaulted and overridden options from
+        # productions
         contents = self._options.get('defaultconfig', {})
 
         for subtree in ast:
@@ -115,7 +116,8 @@ class ApacheConfigLoader(object):
                         return interpolate(self._reader.environ[option])
 
                 if self._options.get('strictvars', True):
-                    raise error.ApacheConfigError('Undefined variable "${%s}" referenced' % option)
+                    raise error.ApacheConfigError(
+                        'Undefined variable "${%s}" referenced' % option)
 
                 return interpolate(match.string)
 
@@ -238,7 +240,9 @@ class ApacheConfigLoader(object):
                 return self.load(filepath, initialize=False)
 
         else:
-            raise error.ConfigFileReadError('Config file "%s" not found in search path %s' % (filename, ':'.join(configpath)))
+            raise error.ConfigFileReadError(
+                'Config file "%s" not found in search path %s'
+                % (filename, ':'.join(configpath)))
 
     def _merge_contents(self, contents, items):
         """Merges items into existing contents dictionary.
@@ -249,8 +253,9 @@ class ApacheConfigLoader(object):
         return contents
 
     def _merge_item(self, contents, key, value, path=[]):
-        """Merges a single "key, value" item into contents dictionary, and returns new contents.
-        Merging rules differ depending on flags set, and whether `value` is a dictionary (block).
+        """Merges a single "key, value" item into contents dictionary, and
+        returns new contents. Merging rules differ depending on flags set,
+        and whether `value` is a dictionary (block).
         """
         if key not in contents:
             contents[key] = value
@@ -263,16 +268,19 @@ class ApacheConfigLoader(object):
         else:
             vector = [value]
 
-        if isinstance(value, dict): # Merge block into contents
+        if isinstance(value, dict):  # Merge block into contents
             if self._options.get('mergeduplicateblocks'):
                 contents = self._merge_dicts(contents[key], value)
             else:
                 if not isinstance(contents[key], list):
                     contents[key] = [contents[key]]
                 contents[key] += vector
-        else: # Merge statement/option into contents
-            if not self._options.get('allowmultioptions', True) and not self._options.get('mergeduplicateoptions', False):
-                raise error.ApacheConfigError('Duplicate option "%s" prohibited' % '.'.join(path + [str(key)]))
+        else:  # Merge statement/option into contents
+            if not self._options.get('allowmultioptions', True) \
+                    and not self._options.get('mergeduplicateoptions', False):
+                raise error.ApacheConfigError(
+                    'Duplicate option "%s" prohibited'
+                    % '.'.join(path + [str(key)]))
             if self._options.get('mergeduplicateoptions', False):
                 contents[key] = value
             else:
@@ -303,7 +311,8 @@ class ApacheConfigLoader(object):
             handler = getattr(self, 'g_' + node_type)
 
         except AttributeError:
-            raise error.ApacheConfigError('Unsupported AST node type %s' % node_type)
+            raise error.ApacheConfigError(
+                'Unsupported AST node type %s' % node_type)
 
         return handler(ast[1:])
 
@@ -355,7 +364,8 @@ class ApacheConfigLoader(object):
         except KeyError:
             pass
 
-        if filepath in self._includes and not self._options.get('includeagain'):
+        if filepath in self._includes and not self._options.get(
+                'includeagain'):
             return {}
 
         self._includes.add(filepath)
@@ -368,7 +378,8 @@ class ApacheConfigLoader(object):
                 return self.loads(f.read(), source=filepath)
 
         except IOError as ex:
-            raise error.ConfigFileReadError('File %s can\'t be open: %s' % (filepath, ex))
+            raise error.ConfigFileReadError('File %s can\'t be open: %s'
+                                            % (filepath, ex))
 
         finally:
             if initialize:
@@ -376,7 +387,8 @@ class ApacheConfigLoader(object):
 
     def _dumpdict(self, obj, indent=0, continue_tag=False):
         if not isinstance(obj, dict):
-            raise error.ApacheConfigError('Unknown object type "%r" to dump' % obj)
+            raise error.ApacheConfigError('Unknown object type "%r" to dump'
+                                          % obj)
 
         text = ''
         spacing = ' ' * indent
@@ -397,26 +409,40 @@ class ApacheConfigLoader(object):
                             text += '%s%s "%s"\n' % (spacing, key, dup)
                     else:
                         if self._options.get('namedblocks', True):
-                            text += '%s<%s>\n%s%s</%s>\n' % (spacing, key, self._dumpdict(dup, indent + 2), spacing, key)
+                            text += ('%s<%s>\n%s%s</%s>\n'
+                                     % (spacing, key,
+                                        self._dumpdict(dup, indent + 2),
+                                        spacing, key))
                         else:
-                            text += '%s<%s %s%s</%s>\n' % (spacing, key, self._dumpdict(dup, indent + 2, continue_tag=True), spacing, key)
+                            text += ('%s<%s %s%s</%s>\n'
+                                     % (spacing, key,
+                                        self._dumpdict(dup, indent + 2,
+                                                       continue_tag=True),
+                                        spacing, key))
 
             else:
                 if self._options.get('namedblocks', True):
-                    text += '%s<%s>\n%s%s</%s>\n' % (spacing, key, self._dumpdict(val, indent + 2), spacing, key)
+                    text += ('%s<%s>\n%s%s</%s>\n'
+                             % (spacing, key, self._dumpdict(val, indent + 2),
+                                spacing, key))
                 else:
                     if continue_tag:
-                        text += '%s>\n%s' % (key, self._dumpdict(val, indent + 2))
+                        text += ('%s>\n%s'
+                                 % (key, self._dumpdict(val, indent + 2)))
                     else:
-                        text += '%s<%s %s%s</%s>\n' % (spacing, key, self._dumpdict(val, indent + 2, continue_tag=True), spacing, key)
+                        text += ('%s<%s %s%s</%s>\n'
+                                 % (spacing, key,
+                                    self._dumpdict(val, indent + 2,
+                                                   continue_tag=True),
+                                    spacing, key))
         return text
-
 
     def dumps(self, dct):
         return self._dumpdict(dct)
 
     def dump(self, filepath, dct):
-        tmpf = tempfile.NamedTemporaryFile(dir=os.path.dirname(filepath), delete=False)
+        tmpf = tempfile.NamedTemporaryFile(dir=os.path.dirname(filepath),
+                                           delete=False)
 
         try:
             with open(tmpf.name, 'w') as f:
@@ -431,4 +457,5 @@ class ApacheConfigLoader(object):
             except Exception:
                 pass
 
-            raise error.ApacheConfigError('File %s can\'t be written: %s' % (filepath, ex))
+            raise error.ApacheConfigError('File %s can\'t be written: %s'
+                                          % (filepath, ex))

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -136,7 +136,8 @@ class BaseApacheConfigParser(object):
             p[0] = ['config', p[1]]
 
     def p_error(self, p):
-        raise ApacheConfigError("Parser error at '%s'" % p.value if p else 'Unexpected EOF')
+        raise ApacheConfigError("Parser error at '%s'" % p.value
+                                if p else'Unexpected EOF')
 
 
 def make_parser(**options):
@@ -160,6 +161,5 @@ def make_parser(**options):
         parser_class = type('ApacheConfigParser',
                             (parser_class, IncludesParser),
                             {'options': options})
-
 
     return parser_class


### PR DESCRIPTION
Using flake8! :) Almost all the edits are just wrapping lines to under 80 characters, as well as defining module exports explicitly in `__init__.py` using `__all__`.

Fixes #46.