### PR TITLE
lexer/parser: save but ignore whitespace and formatting data for includes

### DIFF
--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -144,7 +144,8 @@ class BaseApacheConfigLexer(object):
 
     def t_INCLUDE(self, t):
         r'<<(?i)include[\t ]+[^\n\r\t]+>>'
-        include, whitespace, value = re.split(r'([ \t]+)', t.value[2:-2], maxsplit=1)
+        include, whitespace, value = re.split(r'([ \t]+)',
+                                              t.value[2:-2], maxsplit=1)
         t.value = '<<', include, whitespace, value, '>>'
         return t
 

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -83,12 +83,14 @@ class ApacheIncludesLexer(object):
 
     def t_APACHEINCLUDE(self, t):
         r'(?i)include[\t ]+[^\n\r]+'
-        t.value = t.value.split(None, 1)[1]
+        include, whitespace, value = re.split(r'([ \t]+)', t.value, maxsplit=1)
+        t.value = include, whitespace, value
         return t
 
     def t_APACHEINCLUDEOPTIONAL(self, t):
         r'(?i)includeoptional[\t ]+[^\n\r]+'
-        t.value = t.value.split(None, 1)[1]
+        include, whitespace, value = re.split(r'([ \t]+)', t.value, maxsplit=1)
+        t.value = include, whitespace, value
         return t
 
 
@@ -142,7 +144,8 @@ class BaseApacheConfigLexer(object):
 
     def t_INCLUDE(self, t):
         r'<<(?i)include[\t ]+[^\n\r\t]+>>'
-        t.value = t.value[2:-2].split(None, 1)[1]
+        include, whitespace, value = re.split(r'([ \t]+)', t.value[2:-2], maxsplit=1)
+        t.value = '<<', include, whitespace, value, '>>'
         return t
 
     def t_CLOSE_TAG(self, t):

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -32,7 +32,8 @@ class IncludesParser(object):
         """include : INCLUDE
            includeoptional : INCLUDE
         """
-        p[0] = ['include', p[1]]
+        # lexer returns ['<<', include, whitespace, value, '>>']
+        p[0] = ['include', p[1][3]]
 
 
 class ApacheIncludesParser(object):
@@ -40,12 +41,18 @@ class ApacheIncludesParser(object):
         """include : INCLUDE
                    | APACHEINCLUDE
         """
-        p[0] = ['include', p[1]]
+        # lexer could return ['<<', include, whitespace, value, '>>'] or
+        #                    [include, whitespace, value]
+        filename_index = 2
+        if p[1][0] == '<<':
+            filename_index = 3
+        p[0] = ['include', p[1][filename_index]]
 
     def p_includeoptional(self, p):
         """includeoptional : APACHEINCLUDEOPTIONAL
         """
-        p[0] = ['includeoptional', p[1]]
+        # lexer returns [includeoptional, whitespace, value]
+        p[0] = ['includeoptional', p[1][2]]
 
 
 class BaseApacheConfigParser(object):

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -109,7 +109,8 @@ a "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['first.conf', '\n', 'a', '\n', 'second.conf', '\n', 'a', '\n'])
+        self.assertEqual(tokens, [('<<', 'include', ' ', 'first.conf', '>>'), '\n', 'a', '\n',
+                                ('<<', 'Include', ' ', 'second.conf', '>>'), '\n', 'a', '\n'])
 
     def testIncludesApache(self):
         text = """\
@@ -119,7 +120,8 @@ Include second.conf
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['first.conf', '\n', 'a', '\n', 'second.conf', '\n', 'a', '\n'])
+        self.assertEqual(tokens, [('include', ' ', 'first.conf'), '\n', 'a', '\n',
+                            ('Include', ' ', 'second.conf'), '\n', 'a', '\n'])
 
     def testMultilineOption(self):
         text = """\


### PR DESCRIPTION
Missed includes in the original whitespace-preserving PR. Hopefully this makes sense! We're preserving all the whitespace data before the included filename, though the parser throws that information out for now.