### PR TITLE
Include hash in hashcomment AST

### DIFF
--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -30,7 +30,6 @@ class HashCommentsLexer(object):
 
     def t_HASHCOMMENT(self, t):
         r'(?<!\\)\#[^\n\r]*'
-        t.value = t.value[1:]
         return t
 
 

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -65,7 +65,7 @@ a = "b"
 # a b
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['', '\n', ' a', '\n', 'a', '\n', ' a b', '\n'])
+        self.assertEqual(tokens, ['#', '\n', '# a', '\n', '#a', '\n', '# a b', '\n'])
 
     def testBlockOptionsAndValues(self):
         text = """\
@@ -89,7 +89,7 @@ a "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['a', '\n', '', '\n', ' a', '\n', ' a b', '\n', 'a', '\n'])
+        self.assertEqual(tokens, ['a', '\n', '#', '\n', '# a', '\n', '# a b', '\n', 'a', '\n'])
 
     def testBlockBlankLines(self):
         text = """\
@@ -155,7 +155,7 @@ a = b
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, [' h', '\n', ('a', ' = ', 'b'), '\n', 'a', '\n  ', ('a', ' ', 'b'), '\n', 'a', '\n'])
+        self.assertEqual(tokens, ['# h', '\n', ('a', ' = ', 'b'), '\n', 'a', '\n  ', ('a', ' ', 'b'), '\n', 'a', '\n'])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -57,10 +57,10 @@ c \# # c
 
             ast = parser.parse(text)
             self.assertEqual(ast, ['contents',
-                                   ['comment', 'a'],
-                                   ['comment', ' b'],
+                                   ['comment', '#a'],
+                                   ['comment', '# b'],
                                    ['statement', 'c', 'c'],
-                                   ['comment', ' c'],
+                                   ['comment', '# c'],
                                    ['statement', 'c', '# # c']])
 
     def testCStyleComments(self):
@@ -171,9 +171,9 @@ a "b"
         ast = parser.parse(text)
         self.assertEqual(ast, ['block', 'a',
                                ['contents',
-                                ['comment', 'a'],
+                                ['comment', '#a'],
                                  ['statement', 'a', 'b b'],
-                                ['comment', ' a b'],
+                                ['comment', '# a b'],
                                  ['statement', 'a', 'b b']], 'a'])
 
     def testNestedBlock(self):
@@ -337,7 +337,7 @@ a b
         self.assertEqual(ast, [
             'config',
             ['contents',
-                ['comment', ' a'],
+                ['comment', '# a'],
                 ['statement', 'a', 'b'],
                 ['block', 'a',
                  ['contents', ['statement', 'a', 'b']],
@@ -347,9 +347,9 @@ a b
                  ['contents',
                   ['statement', 'a', 'b'],
                   ['statement', 'c', 'd'],
-                  ['comment', ' c']],
+                  ['comment', '# c']],
                  'a a'],
-                ['comment', ' a']]
+                ['comment', '# a']]
         ])
 
 


### PR DESCRIPTION
Preserving the hash in the AST for hash comments makes processing down-the-line easier. May be helpful for C-style comments as well!