### PR TITLE
fix: preserve escaped newlines and ignore them in parser

### DIFF
--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -165,11 +165,11 @@ class BaseApacheConfigLexer(object):
 
     @staticmethod
     def _parse_option_value(token, lineno):
-        if not re.match(r'.*?[ \n\r\t=]+', token):
+        if not re.match(r'.*?(?:\s|=|\\\s)+', token):
             raise ApacheConfigError(
                 'Syntax error in option-value pair %s on line '
                 '%d' % (token, lineno))
-        option, middle, value = re.split(r'([ \n\r\t=]+)', token, maxsplit=1)
+        option, middle, value = re.split(r'((?:\s|=|\\\s)+)', token, maxsplit=1)
         if not option:
             raise ApacheConfigError(
                 'Syntax error in option-value pair %s on line '
@@ -235,7 +235,6 @@ class BaseApacheConfigLexer(object):
         value = self._remove_trailing_whitespace(value)
         t.lexer.lexpos = t.lexer.code_start + len(value)
         t.lexer.lineno += len(re.findall(r'\r\n|\n|\r', value))
-        value = re.sub(r'(\\\n|\r|\n)', '', value)
 
         option, whitespace, value = self._parse_option_value(value, t.lineno)
 

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -169,7 +169,8 @@ class BaseApacheConfigLexer(object):
             raise ApacheConfigError(
                 'Syntax error in option-value pair %s on line '
                 '%d' % (token, lineno))
-        option, middle, value = re.split(r'((?:\s|=|\\\s)+)', token, maxsplit=1)
+        option, middle, value = re.split(r'((?:\s|=|\\\s)+)', token,
+                                         maxsplit=1)
         if not option:
             raise ApacheConfigError(
                 'Syntax error in option-value pair %s on line '

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -5,6 +5,7 @@
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
 import logging
+import re
 import ply.yacc as yacc
 
 from apacheconfig.error import ApacheConfigError
@@ -99,7 +100,13 @@ class BaseApacheConfigParser(object):
         """statement : OPTION_AND_VALUE
                      | OPTION_AND_VALUE_NOSTRIP
         """
-        p[0] = ['statement', p[1][0], p[1][2]]
+        p[0] = ['statement']
+        # To match perl parser behavior, when the value is split on
+        # multiple lines, whitespace between text is normalized.
+        value = p[1][2]
+        if "\\\n" in value:
+            value = " ".join(re.split(r'(?:\s|\\\s)+', p[1][2]))
+        p[0] += [p[1][0], value]
 
         if self.options.get('lowercasenames'):
             p[0][1] = p[0][1].lower()

--- a/tests/integration/test_perl_samples.py
+++ b/tests/integration/test_perl_samples.py
@@ -24,9 +24,9 @@ test_configs = {
     'array-content-test.conf': {'domain':
                                     ['b0fh.org', 'l0pht.com', 'infonexus.com']},
     'unquoted-values-with-whitespaces.conf': {'option': 'value with whitespaces'},
-    'multiline-option-test.conf': {'command': "ssh -f -g orpheus.0x49.org           "
-                                              "-l azrael -L:34777samir.okir.da.ru:22           "
-                                              "-L:31773:shane.sol1.rocket.de:22           "
+    'multiline-option-test.conf': {'command': "ssh -f -g orpheus.0x49.org "
+                                              "-l azrael -L:34777samir.okir.da.ru:22 "
+                                              "-L:31773:shane.sol1.rocket.de:22 "
                                               "'exec sleep 99999990'"},
     'here-document-test.conf': {'header': '  <table border="0">\n  </table>'},
     'c-style-comment-test.conf': {'passwd': 'sakkra',
@@ -41,7 +41,7 @@ test_configs = {
         },
         'domain': ['nix.to', 'b0fh.org', 'foo.bar'],
         'message': '  yes. we are not here. you\n  can reach us somewhere in\n  outerspace.',
-        'nocomment': 'Comments in a here-doc should not be treated as comments.\n/* So this should appear in the output */', 'command': "ssh -f -g orpheus.0x49.org           -l azrael -L:34777samir.okir.da.ru:22           -L:31773:shane.sol1.rocket.de:22           'exec sleep 99999990'", 'user': 'tom', 'passwd': 'sakkra', 'db': {'host': 'blah.blubber'}, 'beta': [{'user1': 'hans'}, {'user2': 'max'}], 'quoted': 'this one contains whitespace at the end    ', 'quotedwithquotes': ' holy crap, it contains "masked quotes" and \'single quotes\'  '
+        'nocomment': 'Comments in a here-doc should not be treated as comments.\n/* So this should appear in the output */', 'command': "ssh -f -g orpheus.0x49.org -l azrael -L:34777samir.okir.da.ru:22 -L:31773:shane.sol1.rocket.de:22 'exec sleep 99999990'", 'user': 'tom', 'passwd': 'sakkra', 'db': {'host': 'blah.blubber'}, 'beta': [{'user1': 'hans'}, {'user2': 'max'}], 'quoted': 'this one contains whitespace at the end    ', 'quotedwithquotes': ' holy crap, it contains "masked quotes" and \'single quotes\'  '
     },
     'include-file-test.conf': {'seen_first_config': 'true',
                                'seen_second_config': 'true',

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -129,7 +129,7 @@ a \\
 c b  \\
   """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, [('a', ' ', 'c b'), '  \\\n  '])
+        self.assertEqual(tokens, [('a', ' \\\n', 'c b'), '  \\\n  '])
 
     def testNoStripValues(self):
         text = """  a b    """

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -441,7 +441,7 @@ b
 
         config = loader.loads(text)
 
-        self.assertEqual(config, {'a': {'b': 'abc         pqr',
+        self.assertEqual(config, {'a': {'b': 'abc pqr',
                                         'c': 'value2'}})
 
     def testLineContinuationInNestedBlock(self):
@@ -462,7 +462,7 @@ b
 
         config = loader.loads(text)
 
-        self.assertEqual(config, {'a': {'b': 'abc         pqr',
+        self.assertEqual(config, {'a': {'b': 'abc pqr',
                                         'aa': {'c': 'value2'}}})
 
     def testLineContinuationOnEmptyLine(self):


### PR DESCRIPTION
fixes #39
Now the lexer preserves escaped newlines. The parser throws them out for the time being.