### PR TITLE
Create a preserve-whitespace option for the parser

### DIFF
--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -34,7 +34,10 @@ class IncludesParser(object):
            includeoptional : INCLUDE
         """
         # lexer returns ['<<', include, whitespace, value, '>>']
-        p[0] = ['include', p[1][3]]
+        if self._preserve_whitespace:
+            p[0] = ['include'] + p[1]
+        else:
+            p[0] = ['include', p[1][3]]
 
 
 class ApacheIncludesParser(object):
@@ -44,6 +47,9 @@ class ApacheIncludesParser(object):
         """
         # lexer could return ['<<', include, whitespace, value, '>>'] or
         #                    [include, whitespace, value]
+        if self._preserve_whitespace:
+            p[0] = ['include'] + list(p[1])
+            return
         filename_index = 2
         if p[1][0] == '<<':
             filename_index = 3
@@ -53,6 +59,8 @@ class ApacheIncludesParser(object):
         """includeoptional : APACHEINCLUDEOPTIONAL
         """
         # lexer returns [includeoptional, whitespace, value]
+        if self._preserve_whitespace:
+            p[0] = ['includeoptional'] + p[1]
         p[0] = ['includeoptional', p[1][2]]
 
 
@@ -64,6 +72,8 @@ class BaseApacheConfigParser(object):
         self._tempdir = tempdir
         self._debug = debug
         self._start = start
+        self._preserve_whitespace = self.options.get('preserve_whitespace',
+                                                     False)
         self.engine = None
         self.reset()
 
@@ -88,25 +98,28 @@ class BaseApacheConfigParser(object):
     def p_requirednewline(self, p):
         """requirednewline : NEWLINE
         """
-        p[0] = p[1:][0]
+        p[0] = p[1]
 
     def p_whitespace(self, p):
         """whitespace : requirednewline
                       | WHITESPACE
         """
-        p[0] = p[1:][0]
+        p[0] = p[1]
 
     def p_statement(self, p):
         """statement : OPTION_AND_VALUE
                      | OPTION_AND_VALUE_NOSTRIP
         """
         p[0] = ['statement']
-        # To match perl parser behavior, when the value is split on
-        # multiple lines, whitespace between text is normalized.
-        value = p[1][2]
-        if "\\\n" in value:
-            value = " ".join(re.split(r'(?:\s|\\\s)+', p[1][2]))
-        p[0] += [p[1][0], value]
+        if self._preserve_whitespace:
+            p[0] += p[1]
+        else:
+            # To match perl parser behavior, when the value is split on
+            # multiple lines, whitespace between text is normalized.
+            value = p[1][2]
+            if "\\\n" in value:
+                value = " ".join(re.split(r'(?:\s|\\\s)+', p[1][2]))
+            p[0] += [p[1][0], value]
 
         if self.options.get('lowercasenames'):
             p[0][1] = p[0][1].lower()
@@ -124,7 +137,7 @@ class BaseApacheConfigParser(object):
                 | includeoptional
                 | block
         """
-        p[0] = p[1:][0]
+        p[0] = p[1]
 
     def p_startitem(self, p):
         """startitem : whitespace item
@@ -133,9 +146,13 @@ class BaseApacheConfigParser(object):
                      | comment
         """
         if len(p) == 3:
-            p[0] = p[1:][1]
+            if self._preserve_whitespace:
+                item = p[2]
+                p[0] = [item[0]] + [p[1]] + item[1:]
+            else:
+                p[0] = p[2]
         else:
-            p[0] = p[1:][0]
+            p[0] = p[1]
 
     def p_miditem(self, p):
         """miditem : requirednewline item
@@ -143,7 +160,11 @@ class BaseApacheConfigParser(object):
                    | comment
         """
         if len(p) == 3:
-            p[0] = p[1:][1]
+            if self._preserve_whitespace:
+                item = p[2]
+                p[0] = [item[0]] + [p[1]] + item[1:]
+            else:
+                p[0] = p[2]
         else:
             p[0] = p[1:][0]
 
@@ -157,12 +178,16 @@ class BaseApacheConfigParser(object):
         if n == 3:
             if isinstance(p[2], str) and p[2].isspace():
                 # contents whitespace
-                p[0] = p[1]
+                if self._preserve_whitespace:
+                    p[0] = p[1] + [p[2]]
+                else:
+                    p[0] = p[1]
             else:
                 # contents miditem
                 p[0] = p[1] + [p[2]]
         else:
-            if isinstance(p[1], str) and p[1].isspace():
+            if isinstance(p[1], str) and p[1].isspace()\
+             and not self._preserve_whitespace:
                 # whitespace
                 # (if contents only consists of whitespace)
                 p[0] = []

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -60,8 +60,9 @@ class ApacheIncludesParser(object):
         """
         # lexer returns [includeoptional, whitespace, value]
         if self._preserve_whitespace:
-            p[0] = ['includeoptional'] + p[1]
-        p[0] = ['includeoptional', p[1][2]]
+            p[0] = ['includeoptional'] + list(p[1])
+        else:
+            p[0] = ['includeoptional', p[1][2]]
 
 
 class BaseApacheConfigParser(object):
@@ -186,8 +187,8 @@ class BaseApacheConfigParser(object):
                 # contents miditem
                 p[0] = p[1] + [p[2]]
         else:
-            if isinstance(p[1], str) and p[1].isspace()\
-             and not self._preserve_whitespace:
+            if (not self._preserve_whitespace and
+               isinstance(p[1], str) and p[1].isspace()):
                 # whitespace
                 # (if contents only consists of whitespace)
                 p[0] = []

--- a/tests/unit/test_parser_whitespace.py
+++ b/tests/unit/test_parser_whitespace.py
@@ -1,0 +1,111 @@
+#
+# This file is part of apacheconfig software.
+#
+# Copyright (c) 2018-2019, Ilya Etingof <etingof@gmail.com>
+# License: https://github.com/etingof/apacheconfig/LICENSE.rst
+#
+import sys
+
+from apacheconfig import *
+
+try:
+    import unittest2 as unittest
+
+except ImportError:
+    import unittest
+
+
+def _create_parser(options={}, start='contents'):
+    ApacheConfigLexer = make_lexer(**options)
+    ApacheConfigParser = make_parser(**options)
+    return ApacheConfigParser(ApacheConfigLexer(), start=start)
+
+class WhitespaceParserTestCase(unittest.TestCase):
+    def _test_cases(self, cases, tag='contents', options={}):
+        options['preserve_whitespace'] = True
+        parser = _create_parser(start=tag, options=options)
+        for x, expected in cases:
+            got = parser.parse(x)
+            self.assertEqual(got, expected,
+                "When parsing '%s' we got %s, but expected %s" %
+                    (repr(x), got, expected))
+
+    def testOptionAndValue(self):
+        tests = [
+            ('a  b',  ['statement', 'a', '  ', 'b']),
+            ('a = b', ['statement', 'a', ' = ', 'b']),
+            ('a "b c"', ['statement', 'a', ' ', 'b c']),
+        ]
+        self._test_cases(tests, tag='statement')
+
+    def testInclude(self):
+        tests = [
+            ('include   file.conf',  ['include', 'include', '   ', 'file.conf']),
+            ('<<include   file.conf>>', ['include', '<<', 'include', '   ', 'file.conf', '>>']),
+        ]
+        self._test_cases(tests, tag='include')
+
+    def testHashComment(self):
+        comment = '# hello there !!! yep'
+        tests = [(comment, ['comment', comment])]
+        self._test_cases(tests, tag='comment')
+
+    def testContentsWhitespaces(self):
+        tests = [
+            ('\n', ['contents', '\n']),
+            ('a b', ['contents', ['statement', 'a', ' ', 'b']]),
+            ('a b\n ', ['contents', ['statement', 'a', ' ', 'b'], '\n ']),
+            ('\n a b', ['contents', ['statement', '\n ', 'a', ' ', 'b']]),
+            ('\n a b\n',
+             ['contents', ['statement', '\n ', 'a', ' ', 'b'], '\n']),
+            (' \n a b\nb c\n', ['contents',
+                         ['statement', ' \n ', 'a', ' ', 'b'],
+                         ['statement', '\n', 'b', ' ', 'c'], '\n']),
+        ]
+        self._test_cases(tests, tag='contents')
+
+    def testContentsWithComments(self):
+        tests = [
+            ('# a b', ['contents', ['comment', '# a b']]),
+            ('\n # a b', ['contents', ['comment', '\n ', '# a b']]),
+            ('   # a b', ['contents', ['comment', '   ', '# a b']]),
+            ('a b #comment\n  ', ['contents',
+                         ['statement', 'a', ' ', 'b'],
+                         ['comment', ' ', '#comment'], '\n  ']),
+            ('a b \n #comment\n  ', ['contents',
+                         ['statement', 'a', ' ', 'b'],
+                         ['comment', ' \n ', '#comment'], '\n  ']),
+            ('a b #comment\n  #comment2\n c d\n', ['contents',
+                         ['statement', 'a', ' ', 'b'],
+                         ['comment', ' ', '#comment'],
+                         ['comment', '\n  ', '#comment2'],
+                         ['statement', '\n ', 'c', ' ', 'd'], '\n']),
+        ]
+        self._test_cases(tests, tag='contents')
+
+    def testNamedBlocks(self):
+        tests = [
+            ('<a name/>', ['block', 'a name', [], 'a name']),
+            ('<a name>\n</a>', ['block', 'a name', ['contents', '\n'], 'a']),
+        ]
+        self._test_cases(tests, tag='block')
+
+    def testBlocks(self):
+        tests = [
+            ('<a/>', ['block', 'a', [], 'a']),
+            ('<a>\n</a>', ['block', 'a', ['contents', '\n'], 'a']),
+            ('<a> #comment\n</a>',
+             ['block', 'a', ['contents',
+                        ['comment', ' ', '#comment'], '\n'], 'a']),
+            ('<a> #comment\n a b #comment2\n</a>',
+             ['block', 'a', ['contents',
+                        ['comment', ' ', '#comment'],
+                        ['statement', '\n ', 'a', ' ', 'b'],
+                        ['comment', ' ', '#comment2'], '\n'], 'a']),
+        ]
+        self._test_cases(tests, tag='block')
+
+    def testEmptyConfig(self):
+        tests = [(" \n", ['config', ['contents', ' \n']])]
+        self._test_cases(tests, tag='config')
+

--- a/tests/unit/test_parser_whitespace.py
+++ b/tests/unit/test_parser_whitespace.py
@@ -45,6 +45,13 @@ class WhitespaceParserTestCase(unittest.TestCase):
         ]
         self._test_cases(tests, tag='include')
 
+    def testIncludeOptional(self):
+        tests = [
+            ('includeoptional   file.conf',  ['includeoptional', 'includeoptional', '   ', 'file.conf']),
+        ]
+        self._test_cases(tests, tag='includeoptional')
+
+
     def testHashComment(self):
         comment = '# hello there !!! yep'
         tests = [(comment, ['comment', comment])]


### PR DESCRIPTION
up until now, we've been ignoring all the whitespace information in parser.py-- let's create a flag so we can decide not to ignore it, and test that flag as much as we can.

~~Depends on #54 to pass some tests -- see `add whitespace parser tests` commit for this PR's diff.~~ EDIT: #54 merged!