### PR TITLE
fix(lexer): option_and_value can consume and preserve escaped hashes

### DIFF
--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -318,7 +318,7 @@ class OptionLexer(BaseApacheConfigLexer):
 
 class NoStripLexer(BaseApacheConfigLexer):
     def t_OPTION_AND_VALUE_NOSTRIP(self, t):
-        r'[^ \n\r\t=#]+[ \t=]+[^\r\n#]+'  # TODO(etingof) escape hash
+        r'[^ \n\r\t=#]+[ \t=]+(?:\\#|[^\r\n#])+'
         return self._lex_option(t)
 
 

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -180,8 +180,6 @@ class BaseApacheConfigLexer(object):
                 value = DoubleQuotedString(stripped[1:-1])
             if stripped[0] == "'" and stripped[-1] == "'":
                 value = SingleQuotedString(stripped[1:-1])
-        if '#' in value:
-            value = value.replace('\\#', '#')
         return option, middle, value
 
     def _pre_parse_value(self, option, value):
@@ -312,7 +310,9 @@ class BaseApacheConfigLexer(object):
 
 class OptionLexer(BaseApacheConfigLexer):
     def t_OPTION_AND_VALUE(self, t):
-        r'[^ \n\r\t=#]+([ \t=]+[^ \t\r\n#]+)+'
+        r'[^ \n\r\t=#]+([ \t=]+(?:\\#|[^ \t\r\n#])+)+'
+        # Regex above matches (text, (spaces, text)+) where text
+        # can include escaped hashes but not regular ones.
         return self._lex_option(t)
 
 

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -99,7 +99,10 @@ class BaseApacheConfigParser(object):
         """statement : OPTION_AND_VALUE
                      | OPTION_AND_VALUE_NOSTRIP
         """
-        p[0] = ['statement', p[1][0], p[1][2]]
+        value = p[1][2]
+        if "#" in value:
+            value = value.replace('\\#', '#')
+        p[0] = ['statement', p[1][0], value]
 
         if self.options.get('lowercasenames'):
             p[0][1] = p[0][1].lower()

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -99,10 +99,7 @@ class BaseApacheConfigParser(object):
         """statement : OPTION_AND_VALUE
                      | OPTION_AND_VALUE_NOSTRIP
         """
-        value = p[1][2]
-        if "#" in value:
-            value = value.replace('\\#', '#')
-        p[0] = ['statement', p[1][0], value]
+        p[0] = ['statement', p[1][0], p[1][2]]
 
         if self.options.get('lowercasenames'):
             p[0][1] = p[0][1].lower()

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -57,6 +57,16 @@ a = "b"
         tokens = self.lexer.tokenize(text)
         self.assertEqual(tokens, ['    ', 'if a == 1', '\n    ', 'if', '\n    '])
 
+    def testHashEscapes(self):
+        text = "favorite_color \#000000"
+        tokens = self.lexer.tokenize(text)
+        self.assertEqual(tokens, [('favorite_color', ' ', '\#000000')])
+
+    def testHashEscapesAndComments(self):
+        text = "favorite_color \#000000 # comment"
+        tokens = self.lexer.tokenize(text)
+        self.assertEqual(tokens, [('favorite_color', ' ', '\#000000'), ' ', '# comment'])
+
     def testComments(self):
         text = """\
 #

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -61,7 +61,8 @@ c \# # c
                                    ['comment', '# b'],
                                    ['statement', 'c', 'c'],
                                    ['comment', '# c'],
-                                   ['statement', 'c', '# # c']])
+                                   ['statement', 'c', '#'],
+                                   ['comment', '# c']])
 
     def testCStyleComments(self):
         text = """\

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -259,6 +259,8 @@ a "b"
 <aA>
   Bb Cc   \
 
+  key value \# 123 \t  \
+
 </aA>
 """
         options = {
@@ -274,7 +276,8 @@ a "b"
         self.assertEqual(ast, ['contents',
                                ['block', 'aA',
                                 ['contents',
-                                 ['statement', 'Bb', 'Cc   ']],
+                                 ['statement', 'Bb', 'Cc   '],
+                                 ['statement', 'key', 'value \# 123 \t  ']],
                                 'aA']])
 
     def testHereDoc(self):

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -49,6 +49,7 @@ class ParserTestCase(unittest.TestCase):
 # b
 c c# c
 c \# # c
+key value\#123
 """
             ApacheConfigLexer = make_lexer()
             ApacheConfigParser = make_parser()
@@ -61,8 +62,9 @@ c \# # c
                                    ['comment', '# b'],
                                    ['statement', 'c', 'c'],
                                    ['comment', '# c'],
-                                   ['statement', 'c', '#'],
-                                   ['comment', '# c']])
+                                   ['statement', 'c', '\#'],
+                                   ['comment', '# c'],
+                                   ['statement', 'key', 'value\#123']])
 
     def testCStyleComments(self):
         text = """\


### PR DESCRIPTION
Fixes #51 
Fixes #37 
Fixes #21 (I think this one's already been fixed-- just tagging it so all the comment/hash escape issues can get closed)

Also need this for my one-to-one writable loader to preserve hash escapes properly :)

Some context: since the lexer's `OPTION_AND_VALUE` regex disallowed `#` in `value`, values with escaped hashes ended up being processed in `multiline_OPTION_AND_VALUE`. By allowing the regex to consume escaped hashes, this doesn't happen, the value is processed properly and so are inline hash comments.