### PR TITLE
Add missing `preservewhitespace` option to apacheconfigtool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Revision 0.2.9, released XX-10-2019
 - Added line number to the exception message on parsing error
 - Fixed the issue of not collapsing trailing whitespaces into
   one in line continuation (as Perl parser does)
-- Added `preserve_whitespace` option to control parser behaviour
+- Added `preservewhitespace` option to control parser behaviour
   concerning insignificant whitespaces. When this option is
   enabled, the parser would collect all whitespaces into AST
   and (potentially) use them for codegeneration.

--- a/README.md
+++ b/README.md
@@ -364,6 +364,12 @@ you can disable that by setting *ccomments* option to `False`.
 If you want to preserve escaping special characters ($\"#) in the configuration data, turn this parameter on. It is
 set to `False` by default.
 
+### preservewhitespace
+
+When this option is enabled, the parser would collect insignificant whitespaces
+into AST. This information could then be used for code generation. The default
+is `False`.
+
 ## Parser plugins
 
 You can alter the behavior of the parser by supplying callables which will be invoked on certain hooks during

--- a/apacheconfig/apacheconfigtool.py
+++ b/apacheconfig/apacheconfigtool.py
@@ -134,6 +134,12 @@ def main():
     )
 
     options.add_argument(
+        '--preservewhitespace', action='store_true',
+        help=('Preserve insignificant whitespaces, dump them them as is '
+              'on code generation')
+    )
+
+    options.add_argument(
         '--ccomments', action='store_false',
         help='Do not parse C-style comments'
     )

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -73,7 +73,7 @@ class BaseApacheConfigParser(object):
         self._tempdir = tempdir
         self._debug = debug
         self._start = start
-        self._preserve_whitespace = self.options.get('preserve_whitespace',
+        self._preserve_whitespace = self.options.get('preservewhitespace',
                                                      False)
         self.engine = None
         self.reset()

--- a/tests/unit/test_parser_whitespace.py
+++ b/tests/unit/test_parser_whitespace.py
@@ -22,7 +22,7 @@ def _create_parser(options={}, start='contents'):
 
 class WhitespaceParserTestCase(unittest.TestCase):
     def _test_cases(self, cases, tag='contents', options={}):
-        options['preserve_whitespace'] = True
+        options['preservewhitespace'] = True
         parser = _create_parser(start=tag, options=options)
         for x, expected in cases:
             got = parser.parse(x)


### PR DESCRIPTION
Also, renamed `preserve_whitespace` into totally unreadable
`preservewhitespace` for the sake of consistency.