### PR TITLE
fix(lexer): handle no-argument directives properly

### DIFF
--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -166,9 +166,7 @@ class BaseApacheConfigLexer(object):
     @staticmethod
     def _parse_option_value(token, lineno):
         if not re.match(r'.*?(?:\s|=|\\\s)+', token):
-            raise ApacheConfigError(
-                'Syntax error in option-value pair %s on line '
-                '%d' % (token, lineno))
+            return token, None, None
         option, middle, value = re.split(r'((?:\s|=|\\\s)+)', token,
                                          maxsplit=1)
         if not option:
@@ -201,6 +199,9 @@ class BaseApacheConfigLexer(object):
         lineno = len(re.findall(r'\r\n|\n|\r', t.value))
 
         option, whitespace, value = self._parse_option_value(t.value, t.lineno)
+        if not value:
+            t.value = (option,)
+            return t
 
         process, option, value = self._pre_parse_value(option, value)
         if not process:
@@ -310,8 +311,8 @@ class BaseApacheConfigLexer(object):
 
 class OptionLexer(BaseApacheConfigLexer):
     def t_OPTION_AND_VALUE(self, t):
-        r'[^ \n\r\t=#]+([ \t=]+(?:\\#|[^ \t\r\n#])+)+'
-        # Regex above matches (text, (spaces, text)+) where text
+        r'[^ \n\r\t=#]+([ \t=]+(?:\\#|[^ \t\r\n#])+)*'
+        # Regex above matches (text, (spaces, text)*) where text
         # can include escaped hashes but not regular ones.
         return self._lex_option(t)
 

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -115,12 +115,15 @@ class BaseApacheConfigParser(object):
         if self._preserve_whitespace:
             p[0] += p[1]
         else:
-            # To match perl parser behavior, when the value is split on
-            # multiple lines, whitespace between text is normalized.
-            value = p[1][2]
-            if "\\\n" in value:
-                value = " ".join(re.split(r'(?:\s|\\\s)+', p[1][2]))
-            p[0] += [p[1][0], value]
+            if len(p[1]) > 1:
+                # To match perl parser behavior, when the value is split on
+                # multiple lines, whitespace between text is normalized.
+                value = p[1][2]
+                if "\\\n" in value:
+                    value = " ".join(re.split(r'(?:\s|\\\s)+', p[1][2]))
+                p[0] += [p[1][0], value]
+            else:
+                p[0] += p[1]
 
         if self.options.get('lowercasenames'):
             p[0][1] = p[0][1].lower()

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -27,6 +27,7 @@ class LexerTestCase(unittest.TestCase):
 
     def testOptionAndValueSet(self):
         text = """\
+a
 a b
 a = b
 a    b
@@ -37,7 +38,7 @@ a "b"
 a = "b"
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, [('a', ' ',  'b'), '\n', ('a', ' = ', 'b'), '\n', ('a','    ', 'b'), '\n',
+        self.assertEqual(tokens, [('a',), '\n', ('a', ' ',  'b'), '\n', ('a', ' = ', 'b'), '\n', ('a','    ', 'b'), '\n',
                                   ('a', '= ', 'b'), '\n', ('a',' =', 'b'),'\n', ('a','   ', 'b'),'\n',
                                   ('a', ' ', 'b'), '\n', ('a', ' = ','b'), '\n'])
 

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -23,6 +23,9 @@ class ParserTestCase(unittest.TestCase):
 
         parser = ApacheConfigParser(ApacheConfigLexer(), start='statement')
 
+        ast = parser.parse('a')
+        self.assertEqual(ast, ['statement', 'a'])
+
         ast = parser.parse('a b')
         self.assertEqual(ast, ['statement', 'a', 'b'])
 
@@ -96,8 +99,11 @@ key value\#123
             ApacheConfigParser = make_parser(**options)
 
             parser = ApacheConfigParser(ApacheConfigLexer(), start='contents')
-
-            self.assertRaises(ApacheConfigError, parser.parse, text)
+            self.assertEqual(parser.parse(text), ['contents',
+                                                  ['statement', '/*a*/'],
+                                                  ['statement', '/*'],
+                                                  ['comment', '# b'],
+                                                  ['statement', '*/']])
 
     def testIncludes(self):
         text = """\

--- a/tests/unit/test_parser_whitespace.py
+++ b/tests/unit/test_parser_whitespace.py
@@ -32,6 +32,7 @@ class WhitespaceParserTestCase(unittest.TestCase):
 
     def testOptionAndValue(self):
         tests = [
+            ('a',  ['statement', 'a']),
             ('a  b',  ['statement', 'a', '  ', 'b']),
             ('a = b', ['statement', 'a', ' = ', 'b']),
             ('a "b c"', ['statement', 'a', ' ', 'b c']),
@@ -60,6 +61,7 @@ class WhitespaceParserTestCase(unittest.TestCase):
     def testContentsWhitespaces(self):
         tests = [
             ('\n', ['contents', '\n']),
+            ('\na', ['contents', ['statement', '\n', 'a']]),
             ('a b', ['contents', ['statement', 'a', ' ', 'b']]),
             ('a b\n ', ['contents', ['statement', 'a', ' ', 'b'], '\n ']),
             ('\n a b', ['contents', ['statement', '\n ', 'a', ' ', 'b']]),


### PR DESCRIPTION
fix #33 

One behavior change is that if C-style comments are disabled, lines like
```
/*comment*/
/*
*/
```

are interpreted as argument-less directives, like: `{"/*comment*/": None, "/*": None, "*/": None}`. This is consistent with the behavior of Perl's Config::General module.