### PR TITLE
Tokenize block names

### DIFF
--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -170,7 +170,7 @@ class BaseApacheConfigLexer(object):
         if not match:
             raise ApacheConfigError(
                 'Syntax error in option-value pair %s on line '
-                '%d' % (token, lineno)))
+                '%d' % (token, lineno))
         option = match.group(0)
         if len(token) == len(option):
             return token, None, None

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -167,6 +167,10 @@ class BaseApacheConfigLexer(object):
     def _parse_option_value(token, lineno):
         # Grabs the first token before the first non-quoted whitespace.
         match = re.search(r'[^=\s"\']+|"([^"]*)"|\'([^\']*)\'', token)
+        if not match:
+            raise ApacheConfigError(
+                'Syntax error in option-value pair %s on line '
+                '%d' % (token, lineno)))
         option = match.group(0)
         if len(token) == len(option):
             return token, None, None

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -165,10 +165,14 @@ class BaseApacheConfigLexer(object):
 
     @staticmethod
     def _parse_option_value(token, lineno):
-        if not re.match(r'.*?(?:\s|=|\\\s)+', token):
+        # Grabs the first token before the first non-quoted whitespace.
+        match = re.search(r'[^=\s"\']+|"([^"]*)"|\'([^\']*)\'', token)
+        option = match.group(0)
+        if len(token) == len(option):
             return token, None, None
-        option, middle, value = re.split(r'((?:\s|=|\\\s)+)', token,
-                                         maxsplit=1)
+        # If there's more, split it out into whitespace and value.
+        _, middle, value = re.split(r'((?:\s|=|\\\s)+)',
+                                        token[len(option):], maxsplit=1)
         if not option:
             raise ApacheConfigError(
                 'Syntax error in option-value pair %s on line '

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -172,7 +172,7 @@ class BaseApacheConfigLexer(object):
             return token, None, None
         # If there's more, split it out into whitespace and value.
         _, middle, value = re.split(r'((?:\s|=|\\\s)+)',
-                                        token[len(option):], maxsplit=1)
+                                    token[len(option):], maxsplit=1)
         if not option:
             raise ApacheConfigError(
                 'Syntax error in option-value pair %s on line '

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -156,12 +156,12 @@ class BaseApacheConfigLexer(object):
     def t_OPEN_CLOSE_TAG(self, t):
         r'<[^\n\r/]*?[^\n\r/ ]/>'
         t.value = t.value[1:-2]
-        return t
+        return self._lex_option(t)
 
     def t_OPEN_TAG(self, t):
         r'<[^\n\r]+>'
         t.value = t.value[1:-1]
-        return t
+        return self._lex_option(t)
 
     @staticmethod
     def _parse_option_value(token, lineno):

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -166,9 +166,7 @@ class BaseApacheConfigLexer(object):
     @staticmethod
     def _parse_option_value(token, lineno):
         if not re.match(r'.*?(?:\s|=|\\\s)+', token):
-            raise ApacheConfigError(
-                'Syntax error in option-value pair %s on line '
-                '%d' % (token, lineno))
+            return token, None, None
         option, middle, value = re.split(r'((?:\s|=|\\\s)+)', token,
                                          maxsplit=1)
         if not option:
@@ -201,6 +199,9 @@ class BaseApacheConfigLexer(object):
         lineno = len(re.findall(r'\r\n|\n|\r', t.value))
 
         option, whitespace, value = self._parse_option_value(t.value, t.lineno)
+        if not value:
+            t.value = (option,)
+            return t
 
         process, option, value = self._pre_parse_value(option, value)
         if not process:
@@ -310,8 +311,8 @@ class BaseApacheConfigLexer(object):
 
 class OptionLexer(BaseApacheConfigLexer):
     def t_OPTION_AND_VALUE(self, t):
-        r'[^ \n\r\t=#]+([ \t=]+(?:\\#|[^ \t\r\n#])+)+'
-        # Regex above matches (text, (spaces, text)+) where text
+        r'[^ \n\r\t=#]+([ \t=]+(?:\\#|[^ \t\r\n#])+)*'
+        # Regex above matches (text, (spaces, text)*) where text
         # can include escaped hashes but not regular ones.
         return self._lex_option(t)
 

--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -58,20 +58,17 @@ class ApacheConfigLoader(object):
         tag = ast[0]
         values = {}
 
-        if (self._options.get('namedblocks', True) and
-                re.match(r'[^"\'].*?[ \t\r\n]+.*?[^"\']', tag)):
-            tag, name = re.split(r'[ \t\r\n]+', tag, maxsplit=1)
-
-            name = self._unquote_tag(name)
-
+        if not (self._options.get('namedblocks', True)):
+            tag = ("".join(tag),)
+        if len(tag) > 1:
+            name, _, value = tag
             block = {
-                tag: {
-                    name: values
+                name: {
+                    value: values
                 }
             }
-
         else:
-            tag = self._unquote_tag(tag)
+            tag = self._unquote_tag(tag[0])
 
             block = {
                 tag: values

--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -58,7 +58,7 @@ class ApacheConfigLoader(object):
         tag = ast[0]
         values = {}
 
-        if not (self._options.get('namedblocks', True)):
+        if not self._options.get('namedblocks', True):
             tag = ("".join(tag),)
         if len(tag) > 1:
             name, _, value = tag

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -212,7 +212,7 @@ class BaseApacheConfigParser(object):
             p[0] = ['block', p[1], [], "".join(p[1])]
 
         if self.options.get('lowercasenames'):
-            p[0][1] = tuple([x.lower() for x in p[0][1]])
+            p[0][1] = tuple(x.lower() for x in p[0][1])
             p[0][3] = p[0][3].lower()
 
     def p_config(self, p):

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -204,17 +204,16 @@ class BaseApacheConfigParser(object):
                  | OPEN_CLOSE_TAG
         """
         n = len(p)
-        p[1] = "".join(p[1])
         if n == 4:
             if isinstance(p[2], str) and p[2].isspace():
                 p[2] = []
             p[0] = ['block', p[1], p[2], p[3]]
         else:
-            p[0] = ['block', p[1], [], p[1]]
+            p[0] = ['block', p[1], [], "".join(p[1])]
 
         if self.options.get('lowercasenames'):
-            for tag in (1, 3):
-                p[0][tag] = p[0][tag].lower()
+            p[0][1] = tuple([x.lower() for x in p[0][1]])
+            p[0][3] = p[0][3].lower()
 
     def p_config(self, p):
         """config : config contents

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -204,6 +204,7 @@ class BaseApacheConfigParser(object):
                  | OPEN_CLOSE_TAG
         """
         n = len(p)
+        p[1] = "".join(p[1])
         if n == 4:
             if isinstance(p[2], str) and p[2].isspace():
                 p[2] = []

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -115,12 +115,15 @@ class BaseApacheConfigParser(object):
         if self._preserve_whitespace:
             p[0] += p[1]
         else:
-            # To match perl parser behavior, when the value is split on
-            # multiple lines, whitespace between text is normalized.
-            value = p[1][2]
-            if "\\\n" in value:
-                value = " ".join(re.split(r'(?:\s|\\\s)+', p[1][2]))
-            p[0] += [p[1][0], value]
+            if len(p[1]) > 1:
+                # To match perl parser behavior, when the value is split on
+                # multiple lines, whitespace between text is normalized.
+                value = p[1][2]
+                if "\\\n" in value:
+                    value = " ".join(re.split(r'(?:\s|\\\s)+', p[1][2]))
+                p[0] += [p[1][0], value]
+            else:
+                p[0] += p[1]
 
         if self.options.get('lowercasenames'):
             p[0][1] = p[0][1].lower()

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -25,6 +25,14 @@ class LexerTestCase(unittest.TestCase):
         tokens = self.lexer.tokenize(space)
         self.assertEqual(tokens, [space])
 
+    def testOptionAndValueWeirdQuotes(self):
+        text = """\
+"a"
+"a b c d e"
+"""
+        tokens = self.lexer.tokenize(text)
+        self.assertEqual(tokens, [('"a"',), '\n', ('"a b c d e"',), '\n'])
+
     def testOptionAndValueSet(self):
         text = """\
 a

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -27,6 +27,7 @@ class LexerTestCase(unittest.TestCase):
 
     def testOptionAndValueSet(self):
         text = """\
+a
 a b
 a = b
 a    b
@@ -37,7 +38,7 @@ a "b"
 a = "b"
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, [('a', ' ',  'b'), '\n', ('a', ' = ', 'b'), '\n', ('a','    ', 'b'), '\n',
+        self.assertEqual(tokens, [('a',), '\n', ('a', ' ',  'b'), '\n', ('a', ' = ', 'b'), '\n', ('a','    ', 'b'), '\n',
                                   ('a', '= ', 'b'), '\n', ('a',' =', 'b'),'\n', ('a','   ', 'b'),'\n',
                                   ('a', ' ', 'b'), '\n', ('a', ' = ','b'), '\n'])
 

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -48,7 +48,7 @@ a = "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['a', '\n', 'a', '\n'])
+        self.assertEqual(tokens, [('a',), '\n', 'a', '\n'])
 
     def testExpressionTags(self):
         text = """\
@@ -56,7 +56,7 @@ a = "b"
     </if>
     """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['    ', 'if a == 1', '\n    ', 'if', '\n    '])
+        self.assertEqual(tokens, ['    ', ('if', ' ',  'a == 1'), '\n    ', 'if', '\n    '])
 
     def testHashEscapes(self):
         text = "favorite_color \#000000"
@@ -89,7 +89,7 @@ a "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['a', '\n', ('a', ' ', 'b'), '\n', ('a', '=', 'b'), '\n', ('a', ' =  ', 'b'), '\n', ('a', ' = ', 'b'), '\n', ('a',' ', 'b'), '\n', 'a', '\n'])
+        self.assertEqual(tokens, [('a',), '\n', ('a', ' ', 'b'), '\n', ('a', '=', 'b'), '\n', ('a', ' =  ', 'b'), '\n', ('a', ' = ', 'b'), '\n', ('a',' ', 'b'), '\n', 'a', '\n'])
 
     def testBlockComments(self):
         text = """\
@@ -100,7 +100,12 @@ a "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['a', '\n', '#', '\n', '# a', '\n', '# a b', '\n', 'a', '\n'])
+        self.assertEqual(tokens, [('a',), '\n', '#', '\n', '# a', '\n', '# a b', '\n', 'a', '\n'])
+
+    def testEmptyBlock(self):
+        text = "<im   a empty block/>"
+        tokens = self.lexer.tokenize(text)
+        self.assertEqual(tokens, [('im', '   ', 'a empty block')])
 
     def testBlockBlankLines(self):
         text = """\
@@ -110,7 +115,7 @@ a "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['a', '\n\n\n', 'a', '\n'])
+        self.assertEqual(tokens, [('a',), '\n\n\n', 'a', '\n'])
 
     def testIncludesConfigGeneral(self):
         text = """\
@@ -120,7 +125,7 @@ a "b"
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, [('<<', 'include', ' ', 'first.conf', '>>'), '\n', 'a', '\n',
+        self.assertEqual(tokens, [('<<', 'include', ' ', 'first.conf', '>>'), '\n', ('a',), '\n',
                                 ('<<', 'Include', ' ', 'second.conf', '>>'), '\n', 'a', '\n'])
 
     def testIncludesApache(self):
@@ -131,7 +136,7 @@ Include second.conf
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, [('include', ' ', 'first.conf'), '\n', 'a', '\n',
+        self.assertEqual(tokens, [('include', ' ', 'first.conf'), '\n', ('a',), '\n',
                             ('Include', ' ', 'second.conf'), '\n', 'a', '\n'])
 
     def testMultilineOption(self):
@@ -168,7 +173,7 @@ a = b
 </a>
 """
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['# h', '\n', ('a', ' = ', 'b'), '\n', 'a', '\n  ', ('a', ' ', 'b'), '\n', 'a', '\n'])
+        self.assertEqual(tokens, ['# h', '\n', ('a', ' = ', 'b'), '\n', ('a',), '\n  ', ('a', ' ', 'b'), '\n', 'a', '\n'])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -33,6 +33,10 @@ class LexerTestCase(unittest.TestCase):
         tokens = self.lexer.tokenize(text)
         self.assertEqual(tokens, [('"a"',), '\n', ('"a b c d e"',), '\n'])
 
+    def testOptionAndValueEdgeCases(self):
+        text = "="
+        self.assertRaises(ApacheConfigError, self.lexer.tokenize, text)
+
     def testOptionAndValueSet(self):
         text = """\
 a

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -23,6 +23,9 @@ class ParserTestCase(unittest.TestCase):
 
         parser = ApacheConfigParser(ApacheConfigLexer(), start='statement')
 
+        ast = parser.parse('a')
+        self.assertEqual(ast, ['statement', 'a'])
+
         ast = parser.parse('a b')
         self.assertEqual(ast, ['statement', 'a', 'b'])
 
@@ -96,8 +99,11 @@ key value\#123
             ApacheConfigParser = make_parser(**options)
 
             parser = ApacheConfigParser(ApacheConfigLexer(), start='contents')
-
-            self.assertRaises(ApacheConfigError, parser.parse, text)
+            self.assertEqual(parser.parse(text), ['contents',
+                                                  ['statement', '/*a*/'],
+                                                  ['statement', '/*'],
+                                                  ['comment', '# b'],
+                                                  ['statement', '*/']])
 
     def testIncludes(self):
         text = """\

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -178,7 +178,7 @@ a "b"
         parser = ApacheConfigParser(ApacheConfigLexer(), start='block')
 
         ast = parser.parse(text)
-        self.assertEqual(ast, ['block', 'a',
+        self.assertEqual(ast, ['block', ('a',),
                                ['contents',
                                 ['comment', '#a'],
                                  ['statement', 'a', 'b b'],
@@ -199,11 +199,11 @@ a "b"
             parser = ApacheConfigParser(ApacheConfigLexer(), start='block')
 
             ast = parser.parse(text)
-            self.assertEqual(ast, ['block', 'a',
+            self.assertEqual(ast, ['block', ('a',),
                                    ['contents',
-                                    ['block', 'b',
+                                    ['block', ('b',),
                                      ['contents',
-                                      ['block', 'c', [], 'c']], 'b']], 'a'])
+                                      ['block', ('c',), [], 'c']], 'b']], 'a'])
 
     def testEmptyBlocks(self):
         text = """\
@@ -217,8 +217,8 @@ a "b"
 
         ast = parser.parse(text)
         self.assertEqual(ast, ['contents',
-                               ['block', 'a', [], 'a'],
-                               ['block', 'b', [], 'b']])
+                               ['block', ('a',), [], 'a'],
+                               ['block', ('b',), [], 'b']])
 
     def testNamedEmptyBlocks(self):
         text = """\
@@ -233,8 +233,8 @@ a "b"
 
         ast = parser.parse(text)
         self.assertEqual(ast, ['contents',
-                               ['block', 'a A', [], 'a A'],
-                               ['block', 'b B /', [], 'b B /']])
+                               ['block', ('a', ' ', 'A'), [], 'a A'],
+                               ['block', ('b', ' ', 'B /'), [], 'b B /']])
 
     def testLowerCaseNames(self):
         text = """\
@@ -254,8 +254,8 @@ a "b"
 
         ast = parser.parse(text)
         self.assertEqual(ast, ['contents',
-                               ['block', 'a', [], 'a'],
-                               ['block', 'aa',
+                               ['block', ('a',), [], 'a'],
+                               ['block', ('aa',),
                                 ['contents',
                                  ['statement', 'bb', 'Cc']],
                                 'aa']])
@@ -280,7 +280,7 @@ a "b"
 
         ast = parser.parse(text)
         self.assertEqual(ast, ['contents',
-                               ['block', 'aA',
+                               ['block', ('aA',),
                                 ['contents',
                                  ['statement', 'Bb', 'Cc   '],
                                  ['statement', 'key', 'value \# 123 \t  ']],
@@ -304,7 +304,7 @@ a "b"
         ast = parser.parse(text)
 
         self.assertEqual(ast, ['contents',
-                               ['block', 'main',
+                               ['block', ('main',),
                                 ['contents',
                                  ['statement',
                                   'PYTHON', '        def a():\n            x = y\n            return'
@@ -351,11 +351,11 @@ a b
             ['contents',
                 ['comment', '# a'],
                 ['statement', 'a', 'b'],
-                ['block', 'a',
+                ['block', ('a',),
                  ['contents', ['statement', 'a', 'b']],
                  'a'],
                 ['statement', 'a', 'b'],
-                ['block', 'a a',
+                ['block', ('a', ' ', 'a'),
                  ['contents',
                   ['statement', 'a', 'b'],
                   ['statement', 'c', 'd'],

--- a/tests/unit/test_parser_whitespace.py
+++ b/tests/unit/test_parser_whitespace.py
@@ -32,6 +32,7 @@ class WhitespaceParserTestCase(unittest.TestCase):
 
     def testOptionAndValue(self):
         tests = [
+            ('a',  ['statement', 'a']),
             ('a  b',  ['statement', 'a', '  ', 'b']),
             ('a = b', ['statement', 'a', ' = ', 'b']),
             ('a "b c"', ['statement', 'a', ' ', 'b c']),
@@ -60,6 +61,7 @@ class WhitespaceParserTestCase(unittest.TestCase):
     def testContentsWhitespaces(self):
         tests = [
             ('\n', ['contents', '\n']),
+            ('\na', ['contents', ['statement', '\n', 'a']]),
             ('a b', ['contents', ['statement', 'a', ' ', 'b']]),
             ('a b\n ', ['contents', ['statement', 'a', ' ', 'b'], '\n ']),
             ('\n a b', ['contents', ['statement', '\n ', 'a', ' ', 'b']]),

--- a/tests/unit/test_parser_whitespace.py
+++ b/tests/unit/test_parser_whitespace.py
@@ -94,20 +94,20 @@ class WhitespaceParserTestCase(unittest.TestCase):
 
     def testNamedBlocks(self):
         tests = [
-            ('<a name/>', ['block', 'a name', [], 'a name']),
-            ('<a name>\n</a>', ['block', 'a name', ['contents', '\n'], 'a']),
+            ('<a name/>', ['block', ('a', ' ', 'name'), [], 'a name']),
+            ('<a name>\n</a>', ['block', ('a', ' ', 'name'), ['contents', '\n'], 'a']),
         ]
         self._test_cases(tests, tag='block')
 
     def testBlocks(self):
         tests = [
-            ('<a/>', ['block', 'a', [], 'a']),
-            ('<a>\n</a>', ['block', 'a', ['contents', '\n'], 'a']),
+            ('<a/>', ['block', ('a',), [], 'a']),
+            ('<a>\n</a>', ['block', ('a',), ['contents', '\n'], 'a']),
             ('<a> #comment\n</a>',
-             ['block', 'a', ['contents',
+             ['block', ('a',), ['contents',
                         ['comment', ' ', '#comment'], '\n'], 'a']),
             ('<a> #comment\n a b #comment2\n</a>',
-             ['block', 'a', ['contents',
+             ['block', ('a',), ['contents',
                         ['comment', ' ', '#comment'],
                         ['statement', '\n ', 'a', ' ', 'b'],
                         ['comment', ' ', '#comment2'], '\n'], 'a']),


### PR DESCRIPTION
We'd like to be able to write block arguments in the future (while keeping the tag the same)-- so here's a shot at tokenizing that in the lexer, rather than the loader.

Depends on #59 , and should be rebased/merged after that one is. See last 3 commits for full diff of this PR.