### PR TITLE
Multi-line hash comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,10 @@ When this option is enabled, the parser would collect insignificant whitespaces
 into AST. This information could then be used for code generation. The default
 is `False`.
 
+### multilinehashcomments
+
+Escaped newlines at the end of hash comments add the following line to the comment. Apache's native config parser processes hash comments this way. Set to `False` by default.
+
 ## Parser plugins
 
 You can alter the behavior of the parser by supplying callables which will be invoked on certain hooks during

--- a/apacheconfig/apacheconfigtool.py
+++ b/apacheconfig/apacheconfigtool.py
@@ -145,6 +145,11 @@ def main():
     )
 
     options.add_argument(
+        '--multilinehashcomments', action='store_true',
+        help='Enable multi-line hash comments.'
+    )
+
+    options.add_argument(
         '--configpath', action='append', default=[],
         help=('Search path for the configuration files being included. Can '
               'repeat.')

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -68,6 +68,13 @@ a = "b"
         tokens = self.lexer.tokenize(text)
         self.assertEqual(tokens, [('favorite_color', ' ', '\#000000'), ' ', '# comment'])
 
+    def testCommentContinuations(self):
+        text = "# comment \\\n continues"
+        options = { 'multilinehashcomments': True }
+        ApacheConfigLexer = make_lexer(**options)
+        tokens = ApacheConfigLexer().tokenize(text)
+        self.assertEqual(tokens, ['# comment \\\n continues',])
+
     def testComments(self):
         text = """\
 #


### PR DESCRIPTION
fixes #51 ! Adds a new option that enables escaped newlines at the end of hash comments to continue them.