### PR TITLE
Multi-line tag names supported properly

### DIFF
--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -136,6 +136,21 @@ a "b"
         tokens = self.lexer.tokenize(text)
         self.assertEqual(tokens, [('a',), '\n\n\n', 'a', '\n'])
 
+    def testBlockTagWithSpaces(self):
+        text = "<  \t a  >\n</a>"
+        tokens = self.lexer.tokenize(text)
+        self.assertEqual(tokens, [('  \t a  ',), '\n', 'a'])
+
+    def testMultilineBlockNameEmpty(self):
+        text = "<long \\\n bloc\\\n name\\\n     \\\n/>"
+        tokens = self.lexer.tokenize(text)
+        self.assertEqual(tokens, [('long', ' \\\n ', 'bloc\\\n name\\\n     \\\n')])
+
+    def testMultilineBlockName(self):
+        text = "<long \\\n bloc\\\n name\\\n     \\\n>\n</long>"
+        tokens = self.lexer.tokenize(text)
+        self.assertEqual(tokens, [('long', ' \\\n ', 'bloc\\\n name\\\n     \\\n'), '\n', 'long'])
+
     def testIncludesConfigGeneral(self):
         text = """\
 <<include first.conf>>

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -248,7 +248,6 @@ a "b"
 
         parser = ApacheConfigParser(ApacheConfigLexer(), start='contents')
 
-        print ApacheConfigLexer().tokenize(text)
         ast = parser.parse(text)
         self.assertEqual(ast, ['contents',
                                ['block', ('long', '  ', 'bloc  name'), [], 'long  bloc  name']])

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -237,12 +237,7 @@ a "b"
                                ['block', ('b', ' ', 'B /'), [], 'b B /']])
 
     def testMultilineBlocks(self):
-        text = """\
-<long \
- bloc \
- name\
-/>
-"""
+        text = "<long \\\n bloc \\\n name\\\n/>"
         ApacheConfigLexer = make_lexer()
         ApacheConfigParser = make_parser()
 
@@ -250,7 +245,7 @@ a "b"
 
         ast = parser.parse(text)
         self.assertEqual(ast, ['contents',
-                               ['block', ('long', '  ', 'bloc  name'), [], 'long  bloc  name']])
+                               ['block', ('long', ' \\\n ', 'bloc \\\n name\\\n'), [], 'long \\\n bloc \\\n name\\\n']])
 
 
     def testLowerCaseNames(self):

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -236,6 +236,24 @@ a "b"
                                ['block', ('a', ' ', 'A'), [], 'a A'],
                                ['block', ('b', ' ', 'B /'), [], 'b B /']])
 
+    def testMultilineBlocks(self):
+        text = """\
+<long \
+ bloc \
+ name\
+/>
+"""
+        ApacheConfigLexer = make_lexer()
+        ApacheConfigParser = make_parser()
+
+        parser = ApacheConfigParser(ApacheConfigLexer(), start='contents')
+
+        print ApacheConfigLexer().tokenize(text)
+        ast = parser.parse(text)
+        self.assertEqual(ast, ['contents',
+                               ['block', ('long', '  ', 'bloc  name'), [], 'long  bloc  name']])
+
+
     def testLowerCaseNames(self):
         text = """\
 <A/>


### PR DESCRIPTION
fixes #61 
Depends on #60 -- should be merged/rebase afterwards. To see diff, check out the most recent commit.

Beforehands, since we were only matching `<.*>` lines for opening tags, something like:
```
<block \
 name>
```
wouldn't get matched. This changes the open_tag lexing so if it matches on `<.*\`, it performs the regular multiline lexing routine properly!