### PR TITLE
Add option to disable empty-element tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Revision 0.2.9, released XX-10-2019
 - Fixed the issue of not operational `allowmultioptions` option
   when the statement spans multiple lines
 - Fixed the issue of key-only statements parsing
+- Added `disableemptyelementstags` option to disable parsing of
+  empty element tags.
 
 Revision 0.2.8, released 29-12-2018
 -----------------------------------

--- a/README.md
+++ b/README.md
@@ -374,9 +374,9 @@ is `False`.
 
 Escaped newlines at the end of hash comments add the following line to the comment. Apache's native config parser processes hash comments this way. Set to `False` by default.
 
-### disableselfclosingtags
+### disableemptyelementtags
 
-When this option is enabled, the parser does not recognize self-closing tags
+When this option is enabled, the parser does not recognize empty element tags
 such as `<block name/>`. The former, for instance, would be re-interpreted
 as opening tag with tag name `block`, and argument `name/`.
 The default is `False`.

--- a/README.md
+++ b/README.md
@@ -374,6 +374,11 @@ is `False`.
 
 Escaped newlines at the end of hash comments add the following line to the comment. Apache's native config parser processes hash comments this way. Set to `False` by default.
 
+### disableselfclosingtags
+
+When this option is enabled, the parser does not recognize self-closing tags
+such as `<block/>`. The default is `False`.
+
 ## Parser plugins
 
 You can alter the behavior of the parser by supplying callables which will be invoked on certain hooks during

--- a/README.md
+++ b/README.md
@@ -377,7 +377,9 @@ Escaped newlines at the end of hash comments add the following line to the comme
 ### disableselfclosingtags
 
 When this option is enabled, the parser does not recognize self-closing tags
-such as `<block/>`. The default is `False`.
+such as `<block name/>`. The former, for instance, would be re-interpreted
+as opening tag with tag name `block`, and argument `name/`.
+The default is `False`.
 
 ## Parser plugins
 

--- a/apacheconfig/apacheconfigtool.py
+++ b/apacheconfig/apacheconfigtool.py
@@ -140,8 +140,8 @@ def main():
     )
 
     options.add_argument(
-        '--disableselfclosingtags', action='store_true',
-        help=('Disables the parsing of empty, self-closing tags like <block/>')
+        '--disableemptyelementtags', action='store_true',
+        help=('Disables the parsing of empty element tags like <block/>')
     )
 
     options.add_argument(

--- a/apacheconfig/apacheconfigtool.py
+++ b/apacheconfig/apacheconfigtool.py
@@ -140,6 +140,11 @@ def main():
     )
 
     options.add_argument(
+        '--disableselfclosingtags', action='store_true',
+        help=('Disables the parsing of empty, self-closing tags like <block/>')
+    )
+
+    options.add_argument(
         '--ccomments', action='store_false',
         help='Do not parse C-style comments'
     )

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -176,6 +176,9 @@ class BaseApacheConfigLexer(object):
 
     def t_OPEN_CLOSE_TAG(self, t):
         r'<[^\n\r/]*?[^\n\r/ ]/>'
+        if self.options.get('disableselfclosingtags', False):
+            t.type = 'OPEN_TAG'
+            return self.t_OPEN_TAG(t)
         t.value = t.value[1:-2]
         return t
 

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -176,7 +176,7 @@ class BaseApacheConfigLexer(object):
 
     def t_OPEN_CLOSE_TAG(self, t):
         r'<[^\n\r/]*?[^\n\r/ ]/>'
-        if self.options.get('disableselfclosingtags', False):
+        if self.options.get('disableemptyelementtags', False):
             t.type = 'OPEN_TAG'
             return self.t_OPEN_TAG(t)
         t.value = t.value[1:-2]

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -119,6 +119,18 @@ a "b"
         tokens = self.lexer.tokenize(text)
         self.assertEqual(tokens, ['a', '\n\n\n', 'a', '\n'])
 
+    def testSelfClosingTags(self):
+        text = "<block/>"
+        tokens = self.lexer.tokenize(text)
+        self.assertEqual(tokens, ['block'])
+
+    def testSelfClosingTagsDisabled(self):
+        options = { 'disableselfclosingtags': True }
+        text = "<block/>\n<block />\n<block hello/>"
+        ApacheConfigLexer = make_lexer(**options)
+        tokens = ApacheConfigLexer().tokenize(text)
+        self.assertEqual(tokens, ['block/', '\n', 'block /', '\n', 'block hello/'])
+
     def testIncludesConfigGeneral(self):
         text = """\
 <<include first.conf>>

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -119,17 +119,21 @@ a "b"
         tokens = self.lexer.tokenize(text)
         self.assertEqual(tokens, ['a', '\n\n\n', 'a', '\n'])
 
-    def testSelfClosingTags(self):
+    def testEmptyElementTags(self):
         text = "<block/>"
         tokens = self.lexer.tokenize(text)
         self.assertEqual(tokens, ['block'])
 
-    def testSelfClosingTagsDisabled(self):
-        options = { 'disableselfclosingtags': True }
-        text = "<block/>\n<block />\n<block hello/>"
+    def testEmptyElementTagsDisabled(self):
+        options = { 'disableemptyelementtags': True }
+        text = """\
+<block/>
+<block />
+<block hello/>
+"""
         ApacheConfigLexer = make_lexer(**options)
         tokens = ApacheConfigLexer().tokenize(text)
-        self.assertEqual(tokens, ['block/', '\n', 'block /', '\n', 'block hello/'])
+        self.assertEqual(tokens, ['block/', '\n', 'block /', '\n', 'block hello/', '\n'])
 
     def testIncludesConfigGeneral(self):
         text = """\

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -236,6 +236,30 @@ a "b"
                                ['block', 'a A', [], 'a A'],
                                ['block', 'b B /', [], 'b B /']])
 
+    def testNamedBlocksEmptyBlocksDisabled(self):
+        text = """\
+<hello/>
+</hello/>
+<a A/>
+</a A/>
+<b B />
+</b B />
+"""
+
+        options = {
+            'disableselfclosingtags': True
+        }
+        ApacheConfigLexer = make_lexer(**options)
+        ApacheConfigParser = make_parser(**options)
+
+        parser = ApacheConfigParser(ApacheConfigLexer(), start='contents')
+
+        ast = parser.parse(text)
+        self.assertEqual(ast, ['contents',
+                               ['block', 'hello/', [], 'hello/'],
+                               ['block', 'a A/', [], 'a A/'],
+                               ['block', 'b B /', [], 'b B /']])
+
     def testLowerCaseNames(self):
         text = """\
 <A/>

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -247,7 +247,7 @@ a "b"
 """
 
         options = {
-            'disableselfclosingtags': True
+            'disableemptyelementtags': True
         }
         ApacheConfigLexer = make_lexer(**options)
         ApacheConfigParser = make_parser(**options)


### PR DESCRIPTION
Fixes #64 -- disables self-closing tags. Falls back to tokenizing them as open tags, if possible.

This matches native Apache parser behavior.