### PR TITLE
Escape hashes in regexes

### DIFF
--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -351,7 +351,7 @@ class BaseApacheConfigLexer(object):
 
 class OptionLexer(BaseApacheConfigLexer):
     def t_OPTION_AND_VALUE(self, t):
-        r'[^ \n\r\t=#]+([ \t=]+(?:\\#|[^ \t\r\n#])+)*'
+        r'[^ \n\r\t=\#]+([ \t=]+(?:\\\#|[^ \t\r\n\#])+)*'
         # Regex above matches (text, (spaces, text)*) where text
         # can include escaped hashes but not regular ones.
         return self._lex_option(t)
@@ -359,7 +359,7 @@ class OptionLexer(BaseApacheConfigLexer):
 
 class NoStripLexer(BaseApacheConfigLexer):
     def t_OPTION_AND_VALUE_NOSTRIP(self, t):
-        r'[^ \n\r\t=#]+[ \t=]+(?:\\#|[^\r\n#])+'
+        r'[^ \n\r\t=\#]+[ \t=]+(?:\\\#|[^\r\n\#])+'
         return self._lex_option(t)
 
 

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -154,7 +154,7 @@ a "b"
     def testEmptyElementTags(self):
         text = "<block/>"
         tokens = self.lexer.tokenize(text)
-        self.assertEqual(tokens, ['block'])
+        self.assertEqual(tokens, [('block',)])
 
     def testEmptyElementTagsDisabled(self):
         options = { 'disableemptyelementtags': True }
@@ -165,7 +165,7 @@ a "b"
 """
         ApacheConfigLexer = make_lexer(**options)
         tokens = ApacheConfigLexer().tokenize(text)
-        self.assertEqual(tokens, ['block/', '\n', 'block /', '\n', 'block hello/', '\n'])
+        self.assertEqual(tokens, [('block/',), '\n', ('block', ' ', '/'), '\n', ('block', ' ', 'hello/'), '\n'])
 
     def testIncludesConfigGeneral(self):
         text = """\

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -268,9 +268,9 @@ a "b"
 
         ast = parser.parse(text)
         self.assertEqual(ast, ['contents',
-                               ['block', 'hello/', [], 'hello/'],
-                               ['block', 'a A/', [], 'a A/'],
-                               ['block', 'b B /', [], 'b B /']])
+                               ['block', ('hello/',), [], 'hello/'],
+                               ['block', ('a', ' ', 'A/',), [], 'a A/'],
+                               ['block', ('b', ' ', 'B /',), [], 'b B /']])
 
     def testLowerCaseNames(self):
         text = """\


### PR DESCRIPTION
Escaping the hashes should fix #69 !

Depends on #70 just so test suites pass.