### PR TITLE
Fix multiline hash comments

### DIFF
--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -26,31 +26,18 @@ class HashCommentsLexer(object):
         'HASHCOMMENT',
     )
 
-    states = (('hashcomment', 'exclusive'),)
-
-    def t_hashcomment_body(self, t):
-        r'.*(\\\n)$'
-
-    def t_hashcomment_error(self, t):
-        raise ApacheConfigError("Illegal character '%s' in hash comment"
-                                % t.value[0])
-
-    def t_hashcomment_end(self, t):
-        r'.+$'
-        t.value = t.lexer.lexdata[t.lexer.code_start:
-                                  t.lexer.lexpos + len(t.value)]
-        t.type = "HASHCOMMENT"
-        t.lexer.lineno += t.value.count('\n')
-        return t
+    states = ()
 
     def t_HASHCOMMENT(self, t):
-        r'(?<!\\)\#[^\n\r]*'
-
-        if self.options.get('multilinehashcomments'):
-            if t.value.endswith('\\'):
-                t.lexer.code_start = t.lexer.lexpos - len(t.value)
-                t.lexer.begin('hashcomment')
-                return
+        r'(?<!\\)\#(?:(?:\\\n)|[^\n\r])*'
+        # Matches unescaped pound-sign, then escaped newlines or characters
+        if not self.options.get('multilinehashcomments'):
+            # If multiline hash-comments aren't allowed, ignore escaped
+            # newlines
+            if '\n' in t.value:
+                first, second = t.value.split('\n', 1)
+                t.lexer.lexpos = t.lexer.lexpos - len(second) - 1
+                t.value = first
         return t
 
 

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -96,12 +96,45 @@ a = "b"
             ]
         )
 
-    def testCommentContinuations(self):
-        text = "# comment \\\n continues"
-        options = {'multilinehashcomments': True}
+    def testCommentContinuationsDisabled(self):
+        text = "# comment \\\ndoesnt continue"
+        options = { 'multilinehashcomments': False }
         ApacheConfigLexer = make_lexer(**options)
         tokens = ApacheConfigLexer().tokenize(text)
-        self.assertEqual(tokens, ['# comment \\\n continues', ])
+        self.assertEqual(tokens, ['# comment \\', '\n',
+                                  ('doesnt', ' ', 'continue')])
+
+    def testCommentContinuations(self):
+        text = "# comment \\\n continues \\\n multiple lines"
+        options = { 'multilinehashcomments': True }
+        ApacheConfigLexer = make_lexer(**options)
+        tokens = ApacheConfigLexer().tokenize(text)
+        self.assertEqual(tokens,
+                         ['# comment \\\n continues \\\n multiple lines'])
+
+    def testCommentContinuationsEmptyLine(self):
+        text = "# comment \\\n\n# comment"
+        options = { 'multilinehashcomments': True }
+        ApacheConfigLexer = make_lexer(**options)
+        tokens = ApacheConfigLexer().tokenize(text)
+        self.assertEqual(tokens, ['# comment \\\n', '\n', '# comment'])
+
+    def testCommentContinuationsWithOtherComments(self):
+        text = ("# comment \\\n continues \\\n multiple lines\n"
+                "# comment stuff\n hello there")
+        options = { 'multilinehashcomments': True }
+        ApacheConfigLexer = make_lexer(**options)
+        tokens = ApacheConfigLexer().tokenize(text)
+        self.assertEqual(tokens, [
+                         '# comment \\\n continues \\\n multiple lines',
+                         '\n', '# comment stuff', '\n ',
+                         ('hello', ' ', 'there')])
+
+    def testCommentInBlock(self):
+        text = "<block>\n# comment\n</block>"
+        ApacheConfigLexer = make_lexer()
+        tokens = ApacheConfigLexer().tokenize(text)
+        self.assertEqual(tokens, [('block',), '\n', '# comment','\n', 'block'])
 
     def testComments(self):
         text = """\

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -98,15 +98,13 @@ a = "b"
 
     def testCommentContinuationsDisabled(self):
         text = "# comment \\\ndoesnt continue"
-        options = { 'multilinehashcomments': False }
-        ApacheConfigLexer = make_lexer(**options)
-        tokens = ApacheConfigLexer().tokenize(text)
+        tokens = self.lexer.tokenize(text)
         self.assertEqual(tokens, ['# comment \\', '\n',
                                   ('doesnt', ' ', 'continue')])
 
     def testCommentContinuations(self):
         text = "# comment \\\n continues \\\n multiple lines"
-        options = { 'multilinehashcomments': True }
+        options = {'multilinehashcomments': True}
         ApacheConfigLexer = make_lexer(**options)
         tokens = ApacheConfigLexer().tokenize(text)
         self.assertEqual(tokens,
@@ -114,7 +112,7 @@ a = "b"
 
     def testCommentContinuationsEmptyLine(self):
         text = "# comment \\\n\n# comment"
-        options = { 'multilinehashcomments': True }
+        options = {'multilinehashcomments': True}
         ApacheConfigLexer = make_lexer(**options)
         tokens = ApacheConfigLexer().tokenize(text)
         self.assertEqual(tokens, ['# comment \\\n', '\n', '# comment'])
@@ -122,7 +120,7 @@ a = "b"
     def testCommentContinuationsWithOtherComments(self):
         text = ("# comment \\\n continues \\\n multiple lines\n"
                 "# comment stuff\n hello there")
-        options = { 'multilinehashcomments': True }
+        options = {'multilinehashcomments': True}
         ApacheConfigLexer = make_lexer(**options)
         tokens = ApacheConfigLexer().tokenize(text)
         self.assertEqual(tokens, [
@@ -134,7 +132,8 @@ a = "b"
         text = "<block>\n# comment\n</block>"
         ApacheConfigLexer = make_lexer()
         tokens = ApacheConfigLexer().tokenize(text)
-        self.assertEqual(tokens, [('block',), '\n', '# comment','\n', 'block'])
+        self.assertEqual(tokens, [('block',), '\n', '# comment', '\n',
+                                  'block'])
 
     def testComments(self):
         text = """\


### PR DESCRIPTION
This was my bad-- the multiline hash comments were eating the rest of the file instead of ending properly at the next unescaped newline. Fixed the regex to cover all the cases and added lots more tests.