### PR TITLE
Heredocs should preserve whitespace with line breaks.

### DIFF
--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -269,8 +269,13 @@ class BaseApacheConfigLexer(object):
                 t.type = "OPEN_CLOSE_TAG"
                 value = value[:-1]
             value = value[:-1]
-        t.value = option, whitespace, value
 
+        # To match perl parser behavior, whitespace between text is normalized
+        # when a value or block name is on multiple lines.
+        if ("\\\n" in value and not
+           self.options.get('preservewhitespace', False)):
+            value = " ".join(re.split(r'(?:\s|\\\s)+', value))
+        t.value = option, whitespace, value
         return t
 
     def t_multiline_NEWLINE(self, t):

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -5,7 +5,6 @@
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
 import logging
-import re
 import ply.yacc as yacc
 
 from apacheconfig.error import ApacheConfigError
@@ -116,12 +115,7 @@ class BaseApacheConfigParser(object):
             p[0] += p[1]
         else:
             if len(p[1]) > 1:
-                # To match perl parser behavior, when the value is split on
-                # multiple lines, whitespace between text is normalized.
-                value = p[1][2]
-                if "\\\n" in value:
-                    value = " ".join(re.split(r'(?:\s|\\\s)+', p[1][2]))
-                p[0] += [p[1][0], value]
+                p[0] += [p[1][0], p[1][2]]
             else:
                 p[0] += p[1]
 

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -220,7 +220,7 @@ a "b"
         tokens = self.lexer.tokenize(text)
         self.assertEqual(
             tokens, [
-                ('long', ' \\\n ', 'bloc\\\n name\\\n     \\\n')
+                ('long', ' \\\n ', 'bloc name ')
             ]
         )
 
@@ -229,7 +229,7 @@ a "b"
         tokens = self.lexer.tokenize(text)
         self.assertEqual(
             tokens, [
-                ('long', ' \\\n ', 'bloc\\\n name\\\n     \\\n'), '\n', 'long'
+                ('long', ' \\\n ', 'bloc name '), '\n', 'long'
             ]
         )
 

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -29,11 +29,11 @@ except ImportError:
 
 class LoaderTestCase(unittest.TestCase):
 
-    def setUp(self):
-        ApacheConfigLexer = make_lexer()
-        ApacheConfigParser = make_parser()
-        self._loader = ApacheConfigLoader(
-            ApacheConfigParser(ApacheConfigLexer()))
+    def _make_loader(self, **options):
+        ApacheConfigLexer = make_lexer(**options)
+        ApacheConfigParser = make_parser(**options)
+        return ApacheConfigLoader(
+            ApacheConfigParser(ApacheConfigLexer()), **options)
 
     def testLoadWholeConfig(self):
         text = """\
@@ -137,7 +137,7 @@ def fn2():
     return 3
 END
 """
-        config = self._loader.loads(text)
+        config = self._make_loader().loads(text)
         self.assertEqual(config, {'PYTHON': 'def fn():\n        print "hi"\n'
                                   '        return 1 +     fn2()\n\n'
                                   'def fn2():\n    return 3'})

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -29,6 +29,12 @@ except ImportError:
 
 class LoaderTestCase(unittest.TestCase):
 
+    def setUp(self):
+        ApacheConfigLexer = make_lexer()
+        ApacheConfigParser = make_parser()
+        self._loader = ApacheConfigLoader(
+            ApacheConfigParser(ApacheConfigLexer()))
+
     def testLoadWholeConfig(self):
         text = """\
 
@@ -118,6 +124,23 @@ b = [1]
         config = loader.loads(text)
 
         self.assertEqual(config, {'b': ['1']})
+
+    def testHereDocPreservesWhitespace(self):
+        text = """\
+PYTHON <<END
+def fn():
+        print "hi"
+        return 1 + \
+    fn2()
+
+def fn2():
+    return 3
+END
+"""
+        config = self._loader.loads(text)
+        self.assertEqual(config, {'PYTHON': 'def fn():\n        print "hi"\n'
+                                  '        return 1 +     fn2()\n\n'
+                                  'def fn2():\n    return 3'})
 
     def testDuplicateBlocksUnmerged(self):
         text = """\

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -130,7 +130,7 @@ b = [1]
 PYTHON <<END
 def fn():
         print "hi"
-        return 1 + \
+        return 1 + \\
     fn2()
 
 def fn2():
@@ -139,7 +139,7 @@ END
 """
         config = self._make_loader().loads(text)
         self.assertEqual(config, {'PYTHON': 'def fn():\n        print "hi"\n'
-                                  '        return 1 +     fn2()\n\n'
+                                  '        return 1 + \\\n    fn2()\n\n'
                                   'def fn2():\n    return 3'})
 
     def testDuplicateBlocksUnmerged(self):

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -294,7 +294,7 @@ a "b"
         )
 
     def testMultilineBlocks(self):
-        text = "<long \\\n bloc \\\n name\\\n/>"
+        text = "<long \\\n bloc \\\n name\\\n>\n</long>"
         ApacheConfigLexer = make_lexer()
         ApacheConfigParser = make_parser()
 
@@ -305,8 +305,8 @@ a "b"
         self.assertEqual(
             ast, [
                 'contents', ['block', ('long', ' \\\n ',
-                                       'bloc \\\n name\\\n'),
-                             [], 'long \\\n bloc \\\n name\\\n']
+                                       'bloc name '),
+                             [], 'long']
             ]
         )
 
@@ -419,7 +419,7 @@ a "b"
         text = """\
 PYTHON <<MYPYTHON
     def a():
-        x = \
+        x = \\
         y
         return
 MYPYTHON
@@ -427,7 +427,7 @@ MYPYTHON
         ast = self._make_parser().parse(text)
         self.assertEqual(
             ast, ['contents', ['statement', 'PYTHON', '    def a():\n        '
-                               'x =         y\n        return']])
+                               'x = \\\n        y\n        return']])
 
     def testEmptyConfig(self):
         text = " \n "

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -18,11 +18,10 @@ except ImportError:
 
 class ParserTestCase(unittest.TestCase):
 
-    def setUp(self):
-        ApacheConfigLexer = make_lexer()
-        self._parser_class = make_parser()
-        self._lexer = ApacheConfigLexer()
-        self._contents_parser = self._parser_class(self._lexer, start='contents')
+    def _make_parser(self, start='contents', **options):
+        ApacheConfigLexer = make_lexer(**options)
+        ApacheConfigParser = make_parser(**options)
+        return ApacheConfigParser(ApacheConfigLexer(), start=start)
 
     def testOptionAndValue(self):
         ApacheConfigLexer = make_lexer()
@@ -403,7 +402,7 @@ a "b"
     MYPYTHON
 </main>
 """
-        ast = self._contents_parser.parse(text)
+        ast = self._make_parser().parse(text)
 
         self.assertEqual(
             ast, [
@@ -425,11 +424,10 @@ PYTHON <<MYPYTHON
         return
 MYPYTHON
 """
-        ast = self._contents_parser.parse(text)
+        ast = self._make_parser().parse(text)
         self.assertEqual(
             ast, ['contents', ['statement', 'PYTHON', '    def a():\n        '
-                               'x =         y\n        return' ]])
-
+                               'x =         y\n        return']])
 
     def testEmptyConfig(self):
         text = " \n "


### PR DESCRIPTION
~~Reports of bug in #83, heredoc values throwing away whitespace. Added tests to catch
this.~~

Fixes #83 and adds more tests for it.