### PR TITLE
Initial pass at Unicode plumbing.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 Revision 0.2.9, released XX-10-2019
 -----------------------------------
 
+- Added unicode support: library can parse unicode files
 - Added line number to the exception message on parsing error
 - Fixed the issue of not collapsing trailing whitespaces into
   one in line continuation (as Perl parser does)

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -4,8 +4,11 @@
 # Copyright (c) 2018-2019, Ilya Etingof <etingof@gmail.com>
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
+from __future__ import unicode_literals
+
 import logging
 import re
+import six
 import ply.lex as lex
 
 from apacheconfig.error import ApacheConfigError
@@ -13,11 +16,11 @@ from apacheconfig.error import ApacheConfigError
 log = logging.getLogger(__name__)
 
 
-class SingleQuotedString(str):
+class SingleQuotedString(six.text_type):
     is_single_quoted = True
 
 
-class DoubleQuotedString(str):
+class DoubleQuotedString(six.text_type):
     is_double_quoted = True
 
 
@@ -360,7 +363,7 @@ def make_lexer(**options):
     if options.get('nostripvalues'):
         lexer_class = NoStripLexer
 
-    lexer_class = type('ApacheConfigLexer',
+    lexer_class = type(six.binary_type('ApacheConfigLexer'),
                        (lexer_class, HashCommentsLexer),
                        {'tokens': lexer_class.tokens +
                         HashCommentsLexer.tokens,
@@ -369,7 +372,7 @@ def make_lexer(**options):
                         'options': options})
 
     if options.get('ccomments', True):
-        lexer_class = type('ApacheConfigLexer',
+        lexer_class = type(six.binary_type('ApacheConfigLexer'),
                            (lexer_class, CStyleCommentsLexer),
                            {'tokens': lexer_class.tokens +
                             CStyleCommentsLexer.tokens,
@@ -378,7 +381,7 @@ def make_lexer(**options):
                             'options': options})
 
     if options.get('useapacheinclude', True):
-        lexer_class = type('ApacheConfigLexer',
+        lexer_class = type(six.binary_type('ApacheConfigLexer'),
                            (lexer_class, ApacheIncludesLexer),
                            {'tokens': lexer_class.tokens +
                             ApacheIncludesLexer.tokens,

--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -323,10 +323,10 @@ class ApacheConfigLoader(object):
         """Loads config text into a dictionary object.
 
         Args:
-            text (Text): Unicode string containing the configuration to load.
+            text (Text): (Text) containing the configuration to load.
 
         Returns:
-            dict containing configuration information loaded from text.
+            (dict) containing configuration information loaded from text.
         """
         if not text:
             self._ast_cache[source] = {}

--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -7,6 +7,7 @@
 from __future__ import unicode_literals
 
 import glob
+import io
 import logging
 import re
 import os
@@ -319,6 +320,14 @@ class ApacheConfigLoader(object):
         return handler(ast[1:])
 
     def loads(self, text, initialize=True, source=None):
+        """Loads config text into a dictionary object.
+
+        Args:
+            text (Text): Unicode string containing the configuration to load.
+
+        Returns:
+            dict containing configuration information loaded from text.
+        """
         if not text:
             self._ast_cache[source] = {}
             return {}
@@ -440,6 +449,14 @@ class ApacheConfigLoader(object):
         return text
 
     def dumps(self, dct):
+        """Dumps the configuration file in `dict` to a unicode string.
+
+        Args:
+            dct (dict): Configuration represented as a dictionary.
+
+        Returns:
+            Unicode string containing the configuration in given dictionary.
+        """
         return self._dumpdict(dct)
 
     def dump(self, filepath, dct):
@@ -447,7 +464,7 @@ class ApacheConfigLoader(object):
                                            delete=False)
 
         try:
-            with open(tmpf.name, 'w') as f:
+            with io.open(tmpf.name, mode='w', encoding='utf-8') as f:
                 f.write(self.dumps(dct))
 
             os.rename(tmpf.name, filepath)

--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -4,11 +4,14 @@
 # Copyright (c) 2018-2019, Ilya Etingof <etingof@gmail.com>
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
+from __future__ import unicode_literals
+
 import glob
 import logging
 import re
 import os
 import tempfile
+import six
 
 from apacheconfig import error
 from apacheconfig.reader import LocalHostReader
@@ -145,7 +148,7 @@ class ApacheConfigLoader(object):
         def remove_escapes(value):
             if self._options.get('noescape'):
                 return value
-            if not isinstance(value, str):
+            if not isinstance(value, six.text_type):
                 return value
             return re.sub(r'\\([$\\"#])', lambda x: x.groups()[0], value)
         if isinstance(value, list):
@@ -279,7 +282,7 @@ class ApacheConfigLoader(object):
                     and not self._options.get('mergeduplicateoptions', False):
                 raise error.ApacheConfigError(
                     'Duplicate option "%s" prohibited'
-                    % '.'.join(path + [str(key)]))
+                    % '.'.join(path + [six.text_type(key)]))
             if self._options.get('mergeduplicateoptions', False):
                 contents[key] = value
             else:
@@ -393,7 +396,7 @@ class ApacheConfigLoader(object):
         spacing = ' ' * indent
 
         for key, val in obj.items():
-            if isinstance(val, str):
+            if isinstance(val, six.text_type):
                 if val.isalnum():
                     text += '%s%s %s\n' % (spacing, key, val)
                 else:
@@ -401,7 +404,7 @@ class ApacheConfigLoader(object):
 
             elif isinstance(val, list):
                 for dup in val:
-                    if isinstance(dup, str):
+                    if isinstance(dup, six.text_type):
                         if dup.isalnum():
                             text += '%s%s %s\n' % (spacing, key, dup)
                         else:

--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -353,6 +353,15 @@ class ApacheConfigLoader(object):
         return self._ast_cache[source]
 
     def load(self, filepath, initialize=True):
+        """Loads config file into a dictionary object.
+
+        Args:
+            filepath (Text): path of config file to load. Expects UTF-8
+                encoding.
+
+        Returns:
+            dict containing configuration information loaded from file.
+        """
         if initialize:
             self._stack = []
             self._includes = set()
@@ -449,7 +458,7 @@ class ApacheConfigLoader(object):
         return text
 
     def dumps(self, dct):
-        """Dumps the configuration file in `dict` to a unicode string.
+        """Dumps the configuration in `dct` to a unicode string.
 
         Args:
             dct (dict): Configuration represented as a dictionary.
@@ -460,6 +469,12 @@ class ApacheConfigLoader(object):
         return self._dumpdict(dct)
 
     def dump(self, filepath, dct):
+        """Dumps the configuration in `dct` to a file.
+
+        Args:
+            filepath (Text): Filepath to write config to, in UTF-8 encoding.
+            dct (dict): Configuration represented as a dictionary.
+        """
         tmpf = tempfile.NamedTemporaryFile(dir=os.path.dirname(filepath),
                                            delete=False)
 

--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -464,7 +464,7 @@ class ApacheConfigLoader(object):
             dct (dict): Configuration represented as a dictionary.
 
         Returns:
-            Unicode string containing the configuration in given dictionary.
+            (Text) containing the configuration in given dictionary.
         """
         return self._dumpdict(dct)
 

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -4,8 +4,11 @@
 # Copyright (c) 2018-2019, Ilya Etingof <etingof@gmail.com>
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
+from __future__ import unicode_literals
+
 import logging
 import ply.yacc as yacc
+import six
 
 from apacheconfig.error import ApacheConfigError
 
@@ -174,7 +177,7 @@ class BaseApacheConfigParser(object):
         """
         n = len(p)
         if n == 3:
-            if isinstance(p[2], str) and p[2].isspace():
+            if isinstance(p[2], six.text_type) and p[2].isspace():
                 # contents whitespace
                 if self._preserve_whitespace:
                     p[0] = p[1] + [p[2]]
@@ -185,7 +188,7 @@ class BaseApacheConfigParser(object):
                 p[0] = p[1] + [p[2]]
         else:
             if (not self._preserve_whitespace and
-               isinstance(p[1], str) and p[1].isspace()):
+               isinstance(p[1], six.text_type) and p[1].isspace()):
                 # whitespace
                 # (if contents only consists of whitespace)
                 p[0] = []
@@ -199,7 +202,7 @@ class BaseApacheConfigParser(object):
         """
         n = len(p)
         if n == 4:
-            if isinstance(p[2], str) and p[2].isspace():
+            if isinstance(p[2], six.text_type) and p[2].isspace():
                 p[2] = []
             p[0] = ['block', p[1], p[2], p[3]]
         else:
@@ -229,20 +232,20 @@ def make_parser(**options):
     parser_class = BaseApacheConfigParser
 
     if options.get('ccomments', True):
-        parser_class = type('ApacheConfigParser',
+        parser_class = type(six.binary_type('ApacheConfigParser'),
                             (parser_class, CStyleCommentsParser),
                             {'options': options})
     else:
-        parser_class = type('ApacheConfigParser',
+        parser_class = type(six.binary_type('ApacheConfigParser'),
                             (parser_class, HashCommentsParser),
                             {'options': options})
 
     if options.get('useapacheinclude', True):
-        parser_class = type('ApacheConfigParser',
+        parser_class = type(six.binary_type('ApacheConfigParser'),
                             (parser_class, ApacheIncludesParser),
                             {'options': options})
     else:
-        parser_class = type('ApacheConfigParser',
+        parser_class = type(six.binary_type('ApacheConfigParser'),
                             (parser_class, IncludesParser),
                             {'options': options})
 

--- a/apacheconfig/reader.py
+++ b/apacheconfig/reader.py
@@ -1,4 +1,5 @@
 import os
+import io
 
 
 class LocalHostReader(object):
@@ -21,5 +22,5 @@ class LocalHostReader(object):
     def listdir(self, filepath):
         return self._os.listdir(filepath)
 
-    def open(self, filename, mode='r', bufsize=-1):
-        return open(filename, mode, bufsize)
+    def open(self, filename, mode='r', encoding='utf-8', bufsize=-1):
+        return io.open(filename, mode, bufsize, encoding=encoding)

--- a/apacheconfig/wloader.py
+++ b/apacheconfig/wloader.py
@@ -27,7 +27,7 @@ class AbstractASTNode(object):
 
     @abc.abstractmethod
     def dump(self):
-        """Returns the contents of this node as in a config file."""
+        """Dumps contents of this node to a unicode string."""
 
     @abc.abstractproperty
     def typestring(self):
@@ -116,7 +116,7 @@ class LeafASTNode(AbstractASTNode):
         config string.
 
         Args:
-            raw_str (string): The text to parse.
+            raw_str (Text): The text to parse, as a unicode string.
             parser (:class:`apacheconfig.ApacheConfigParser`): specify the
                 parser to use. Can be created by ``native_apache_parser()``.
         Returns:
@@ -172,8 +172,13 @@ class LeafASTNode(AbstractASTNode):
                 "".join([_restore_original(word) for word in self._raw]))
 
     def __str__(self):
+        contents = [_restore_original(word) for word in self._raw]
         return ("%s(%s)"
-                % (self.__class__.__name__,
-                   six.text_type(
-                       [self._type] +
-                       [_restore_original(word) for word in self._raw])))
+                % (str(self.__class__.__name__),
+                   str([self._type] + contents)))
+
+    def __unicode__(self):
+        contents = [_restore_original(word) for word in self._raw]
+        return ("%s(%s)"
+                % (six.text_type(self.__class__.__name__),
+                   six.text_type([self._type] + contents)))

--- a/apacheconfig/wloader.py
+++ b/apacheconfig/wloader.py
@@ -35,7 +35,7 @@ class AbstractASTNode(object):
 
     @abc.abstractproperty
     def whitespace(self):
-        """Returns preceding or trailing whitespace for this node as a string.
+        """Returns preceding or trailing whitespace as a unicode string.
         """
 
     @abc.abstractmethod
@@ -44,7 +44,7 @@ class AbstractASTNode(object):
         """Set preceding or trailing whitespace for this node.
 
         Args:
-            value (str): value to set whitespace to.
+            value (Text): value to set whitespace to.
         """
 
 
@@ -146,7 +146,7 @@ class LeafASTNode(AbstractASTNode):
 
     @property
     def value(self):
-        """Returns the value of this item as a string.
+        """Returns the value of this item as a unicode string.
 
         The "value" is anything but the name. Can be overwritten.
         """
@@ -159,7 +159,7 @@ class LeafASTNode(AbstractASTNode):
         """Sets for the value of this item.
 
         Args:
-            value (str): string to set new value to.
+            value (Text): string to set new value to.
 
           .. todo:: (sydneyli) convert `value` to quotedstring when quoted
         """

--- a/apacheconfig/wloader.py
+++ b/apacheconfig/wloader.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2018-2019, Ilya Etingof <etingof@gmail.com>
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
+from __future__ import unicode_literals
+
 import abc
 import six
 
@@ -172,5 +174,6 @@ class LeafASTNode(AbstractASTNode):
     def __str__(self):
         return ("%s(%s)"
                 % (self.__class__.__name__,
-                   str([self._type] +
+                   six.text_type(
+                       [self._type] +
                        [_restore_original(word) for word in self._raw])))

--- a/apacheconfig/wloader.py
+++ b/apacheconfig/wloader.py
@@ -69,7 +69,7 @@ class AbstractASTNode(object):
         """Dumps contents of this node.
 
         Returns:
-            Unicode string with the contents of this node, as in a config file.
+            (Text) with the contents of this node, as in a config file.
         """
 
     @abc.abstractproperty

--- a/tests/integration/samples/perl-config-general/combination-of-constructs.conf
+++ b/tests/integration/samples/perl-config-general/combination-of-constructs.conf
@@ -8,6 +8,7 @@
       age  31
   </officer>
 </cops>
+域名 unicode.example.com
 domain  nix.to
 domain	b0fh.org
 domain  foo.bar

--- a/tests/integration/test_perl_samples.py
+++ b/tests/integration/test_perl_samples.py
@@ -1,9 +1,12 @@
+# -*- coding: utf-8 -*-
 #
 # This file is part of apacheconfig software.
 #
 # Copyright (c) 2018-2019, Ilya Etingof <etingof@gmail.com>
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
+from __future__ import unicode_literals
+
 import os
 import sys
 
@@ -75,8 +78,9 @@ TEST_CONFIGS = {
         "domain": [
             "nix.to",
             "b0fh.org",
-            "foo.bar"
+            "foo.bar",
         ],
+        "域名": "unicode.example.com",
         "message": "  yes. we are not here. you\n  can reach us somewhere in\n"
                    "  outerspace.",
         "nocomment": "Comments in a here-doc should not be treated as "

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -1,9 +1,12 @@
+# -*- coding: utf-8 -*-
 #
 # This file is part of apacheconfig software.
 #
 # Copyright (c) 2018-2019, Ilya Etingof <etingof@gmail.com>
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
+from __future__ import unicode_literals
+
 import sys
 
 from apacheconfig import ApacheConfigError
@@ -25,6 +28,12 @@ class LexerTestCase(unittest.TestCase):
         space = '   \t\t  \t \r  \n\n'
         tokens = self.lexer.tokenize(space)
         self.assertEqual(tokens, [space])
+
+    def testUnicodeSupport(self):
+        text = 'a = 三\n'
+        tokens = self.lexer.tokenize(text)
+        self.assertEqual(
+            tokens, [('a', ' = ', '三'), '\n'])
 
     def testOptionAndValueWeirdQuotes(self):
         text = """\

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -7,8 +7,11 @@
 #
 from __future__ import unicode_literals
 
+import io
 import os
+import shutil
 import sys
+import tempfile
 
 from apacheconfig import ApacheConfigError
 from apacheconfig import ApacheConfigLoader
@@ -110,10 +113,17 @@ a b
             ApacheConfigParser(ApacheConfigLexer()))
 
         config = loader.loads(text)
-
         gen_text = loader.dumps(config)
-
         self.assertEqual(expect_text, gen_text)
+
+        # Testing dump(filepath, config)
+        tmpd = tempfile.mkdtemp()
+        filepath = os.path.join(tmpd, "config")
+        loader.dump(filepath, config)
+        with io.open(filepath, mode='r', encoding='utf-8') as f:
+            text = f.read()
+        shutil.rmtree(tmpd)
+        self.assertEqual(expect_text, text)
 
     def testForceArray(self):
         text = """\

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1,9 +1,12 @@
+# -*- coding: utf-8 -*-
 #
 # This file is part of apacheconfig software.
 #
 # Copyright (c) 2018-2019, Ilya Etingof <etingof@gmail.com>
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
+from __future__ import unicode_literals
+
 import os
 import sys
 
@@ -40,6 +43,7 @@ class LoaderTestCase(unittest.TestCase):
 
 # a
 a = b
+b = 三
 
 <a block>
   a = b
@@ -60,6 +64,7 @@ c "d d"
 
         self.assertEqual(
             config, {
+                'b': '三',
                 'a': ['b', {'block': {'a': 'b'}}, 'b',
                       {'a block': {'c': 'd d'}}]
             }

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -82,6 +82,7 @@ a = b
 a b
 <a a block>
 c "d d"
+b = 三
 </a>
 # a
 """
@@ -97,6 +98,7 @@ a b
 <a>
   <a block>
     c "d d"
+    b 三
   </a block>
 </a>
 """

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,9 +1,12 @@
+# -*- coding: utf-8 -*-
 #
 # This file is part of apacheconfig software.
 #
 # Copyright (c) 2018-2019, Ilya Etingof <etingof@gmail.com>
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
+from __future__ import unicode_literals
+
 import sys
 
 from apacheconfig import make_lexer
@@ -22,6 +25,14 @@ class ParserTestCase(unittest.TestCase):
         ApacheConfigLexer = make_lexer(**options)
         ApacheConfigParser = make_parser(**options)
         return ApacheConfigParser(ApacheConfigLexer(), start=start)
+
+    def testUnicodeSupport(self):
+        ApacheConfigLexer = make_lexer()
+        ApacheConfigParser = make_parser()
+        parser = ApacheConfigParser(ApacheConfigLexer(), start='statement')
+
+        ast = parser.parse('a = 三')
+        self.assertEqual(ast, ['statement', 'a', '三'])
 
     def testOptionAndValue(self):
         ApacheConfigLexer = make_lexer()

--- a/tests/unit/test_wloader.py
+++ b/tests/unit/test_wloader.py
@@ -4,6 +4,10 @@
 # Copyright (c) 2018-2019, Ilya Etingof <etingof@gmail.com>
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
+from __future__ import unicode_literals
+
+import six
+
 try:
     import unittest2 as unittest
 
@@ -79,8 +83,9 @@ class WLoaderTestCaseRead(unittest.TestCase):
                               "but got '%s'" % (repr(raw), node.dump())))
             self.assertEqual(expected_type, node.typestring,
                              ("Expected node('%s').typestring to be '%s', "
-                              "but got '%s'" % (repr(raw), expected_type,
-                                                str(node.typestring))))
+                              "but got '%s'" %
+                              (repr(raw), expected_type,
+                               six.text_type(node.typestring))))
 
     def testLoadStatement(self):
         cases = [

--- a/tests/unit/test_wloader.py
+++ b/tests/unit/test_wloader.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # This file is part of apacheconfig software.
 #
@@ -115,3 +116,18 @@ class WLoaderTestCaseRead(unittest.TestCase):
             ('\ninclude path', 'include', 'path'),
         ]
         self._test_item_cases(cases, 'include', self.parser)
+
+    def testDumpUnicodeSupport(self):
+        text = "\n value is 三"
+        node = LeafASTNode.parse(text, self.parser)
+        dump = node.dump()
+        self.assertTrue(isinstance(dump, six.text_type))
+        self.assertEquals(dump, text)
+
+    def testStrUnicodeBuiltIns(self):
+        node = LeafASTNode.parse("\n option value", self.parser)
+        self.assertTrue(isinstance(str(node), str))
+        self.assertTrue(isinstance(node.__unicode__(), six.text_type))
+        self.assertEquals(
+            "LeafASTNode([u'statement', u'option', u' ', u'value'])",
+            six.text_type(node))


### PR DESCRIPTION
Fixes #85.
This is a pass at the following tasks, needed for unicode support:
 * Decode `utf-8` wherever we process input. The places where we expect input are relatively few -- all through the loader
 * import unicode_literal from `__future__` on all files with string literals
 * `str` conversions go through the Python 2/3-compatible `six.text_type`

This may not be a comprehensive list, and my first pass may not have knocked them all out thoroughly. Let's see how Travis handles this.