### PR TITLE
Exposed public interface for writable loader

### DIFF
--- a/apacheconfig/__init__.py
+++ b/apacheconfig/__init__.py
@@ -6,18 +6,24 @@ from contextlib import contextmanager
 from apacheconfig.lexer import make_lexer
 from apacheconfig.parser import make_parser
 from apacheconfig.loader import ApacheConfigLoader
+from apacheconfig.wloader import ApacheConfigWritableLoader
 from apacheconfig.error import ApacheConfigError
-from apacheconfig.wloader import make_writable_loader  # noqa: F401
 from apacheconfig import flavors  # noqa: F401
 
 
 @contextmanager
-def make_loader(**options):
+def make_loader(writable=False, **options):
     ApacheConfigLexer = make_lexer(**options)
     ApacheConfigParser = make_parser(**options)
 
-    yield ApacheConfigLoader(ApacheConfigParser(ApacheConfigLexer()),
-                             **options)
+    if writable:
+        options["preservewhitespace"] = True
+        yield ApacheConfigWritableLoader(
+                ApacheConfigParser(ApacheConfigLexer(), start='contents'),
+                **options)
+    else:
+        yield ApacheConfigLoader(ApacheConfigParser(ApacheConfigLexer()),
+                                 **options)
 
 
 __all__ = ['make_lexer', 'make_parser', 'make_loader',

--- a/apacheconfig/__init__.py
+++ b/apacheconfig/__init__.py
@@ -7,6 +7,8 @@ from apacheconfig.lexer import make_lexer
 from apacheconfig.parser import make_parser
 from apacheconfig.loader import ApacheConfigLoader
 from apacheconfig.error import ApacheConfigError
+from apacheconfig.wloader import make_writable_loader  # noqa: F401
+from apacheconfig import flavors  # noqa: F401
 
 
 @contextmanager

--- a/apacheconfig/wloader.py
+++ b/apacheconfig/wloader.py
@@ -17,19 +17,14 @@ from apacheconfig.reader import LocalHostReader
 from apacheconfig import error
 
 
-@contextlib.contextmanager
-def make_writable_loader(**options):
-    # Preserve whitespace is necessary for the writable loader to work.
-    options['preservewhitespace'] = True
-    ApacheConfigLexer = make_lexer(**options)
-    ApacheConfigParser = make_parser(**options)
-    yield ApacheConfigWritableLoader(ApacheConfigParser(ApacheConfigLexer(),
-                                                        start='contents'),
-                                     **options)
-
-
 class ApacheConfigWritableLoader(object):
     """Manages a writable object represented by a single config file.
+
+    Args:
+        parser (:class:`apacheconfig.ApacheConfigParser`): compiled parser
+            to use when loading configuration directives.
+        options (dict): keyword args of options to set for loader. Should be
+            same set of options passed to parser.
     """
 
     def __init__(self, parser, **options):
@@ -65,7 +60,6 @@ class ApacheConfigWritableLoader(object):
         Returns:
             :class:`apacheconfig.ListNode` AST containing parsed config.
         """
-        print text
         ast = self._parser.parse(text)
         return ListNode(ast, self._parser)
 

--- a/apacheconfig/wloader.py
+++ b/apacheconfig/wloader.py
@@ -8,10 +8,7 @@ from __future__ import unicode_literals
 
 import abc
 import six
-import contextlib
 
-from apacheconfig.lexer import make_lexer
-from apacheconfig.parser import make_parser
 from apacheconfig.reader import LocalHostReader
 
 from apacheconfig import error

--- a/apacheconfig/wloader.py
+++ b/apacheconfig/wloader.py
@@ -65,6 +65,7 @@ class ApacheConfigWritableLoader(object):
         Returns:
             :class:`apacheconfig.ListNode` AST containing parsed config.
         """
+        print text
         ast = self._parser.parse(text)
         return ListNode(ast, self._parser)
 

--- a/tests/unit/test_wloader.py
+++ b/tests/unit/test_wloader.py
@@ -20,14 +20,14 @@ import shutil
 import tempfile
 
 from apacheconfig import flavors
-from apacheconfig.wloader import make_writable_loader
+from apacheconfig import make_loader
 from apacheconfig.error import ApacheConfigError
 
 
 class WLoaderTestCaseWrite(unittest.TestCase):
 
     def setUp(self):
-        context = make_writable_loader(**flavors.NATIVE_APACHE)
+        context = make_loader(writable=True, **flavors.NATIVE_APACHE)
         self.loader = context.__enter__()
         self.addCleanup(context.__exit__, None, None, None)
 
@@ -93,7 +93,7 @@ class WLoaderTestCaseWrite(unittest.TestCase):
 class WLoaderTestCaseRead(unittest.TestCase):
 
     def setUp(self):
-        context = make_writable_loader(**flavors.NATIVE_APACHE)
+        context = make_loader(writable=True, **flavors.NATIVE_APACHE)
         self.loader = context.__enter__()
         self.addCleanup(context.__exit__, None, None, None)
 

--- a/tests/unit/test_wloader.py
+++ b/tests/unit/test_wloader.py
@@ -20,8 +20,6 @@ import shutil
 import tempfile
 
 from apacheconfig import flavors
-from apacheconfig import make_lexer
-from apacheconfig import make_parser
 from apacheconfig.wloader import make_writable_loader
 from apacheconfig.error import ApacheConfigError
 

--- a/tests/unit/test_wloader.py
+++ b/tests/unit/test_wloader.py
@@ -15,21 +15,23 @@ try:
 except ImportError:
     import unittest
 
+import os
+import shutil
+import tempfile
+
 from apacheconfig import flavors
 from apacheconfig import make_lexer
 from apacheconfig import make_parser
-from apacheconfig.wloader import BlockNode
-from apacheconfig.wloader import LeafNode
-from apacheconfig.wloader import ListNode
+from apacheconfig.wloader import make_writable_loader
 from apacheconfig.error import ApacheConfigError
 
 
 class WLoaderTestCaseWrite(unittest.TestCase):
 
     def setUp(self):
-        ApacheConfigLexer = make_lexer(**flavors.NATIVE_APACHE)
-        ApacheConfigParser = make_parser(**flavors.NATIVE_APACHE)
-        self.parser = ApacheConfigParser(ApacheConfigLexer(), start="contents")
+        context = make_writable_loader(**flavors.NATIVE_APACHE)
+        self.loader = context.__enter__()
+        self.addCleanup(context.__exit__, None, None, None)
 
     def testChangeItemValue(self):
         cases = [
@@ -43,7 +45,7 @@ class WLoaderTestCaseWrite(unittest.TestCase):
              'include new/path/to/file'),
         ]
         for raw, new_value, expected in cases:
-            node = LeafNode.parse(raw, self.parser)
+            node = next(iter(self.loader.loads(raw)))
             node.value = new_value
             self.assertEqual(expected, node.dump())
 
@@ -53,7 +55,7 @@ class WLoaderTestCaseWrite(unittest.TestCase):
             ("<block>\n</block>", "name2", "<block name2>\n</block>"),
         ]
         for raw, new_value, expected in cases:
-            node = BlockNode.parse(raw, self.parser)
+            node = next(iter(self.loader.loads(raw)))
             node.arguments = new_value
             self.assertEqual(expected, node.dump())
 
@@ -72,7 +74,7 @@ class WLoaderTestCaseWrite(unittest.TestCase):
             ("# comment\n", 0, "\n1 2", "\n1 2\n# comment\n"),
         ]
         for raw, index, to_add, expected in cases:
-            node = ListNode.parse(raw, self.parser)
+            node = self.loader.loads(raw)
             node.add(index, to_add)
             self.assertEqual(expected, node.dump())
 
@@ -85,7 +87,7 @@ class WLoaderTestCaseWrite(unittest.TestCase):
             ("a # comment", 0, " # comment")
         ]
         for raw, index, expected in cases:
-            node = ListNode.parse(raw, self.parser)
+            node = self.loader.loads(raw)
             node.remove(index)
             self.assertEqual(expected, node.dump())
 
@@ -93,9 +95,9 @@ class WLoaderTestCaseWrite(unittest.TestCase):
 class WLoaderTestCaseRead(unittest.TestCase):
 
     def setUp(self):
-        ApacheConfigLexer = make_lexer(**flavors.NATIVE_APACHE)
-        ApacheConfigParser = make_parser(**flavors.NATIVE_APACHE)
-        self.parser = ApacheConfigParser(ApacheConfigLexer(), start="contents")
+        context = make_writable_loader(**flavors.NATIVE_APACHE)
+        self.loader = context.__enter__()
+        self.addCleanup(context.__exit__, None, None, None)
 
     def testChangeItemValue(self):
         cases = [
@@ -109,15 +111,13 @@ class WLoaderTestCaseRead(unittest.TestCase):
              'include new/path/to/file'),
         ]
         for raw, new_value, expected in cases:
-            node = LeafNode.parse(raw, self.parser)
+            node = next(iter(self.loader.loads(raw)))
             node.value = new_value
             self.assertEqual(expected, node.dump())
 
-    def _test_item_cases(self, cases, expected_type, parser=None):
-        if not parser:
-            parser = self.parser
+    def _test_item_cases(self, cases, expected_type):
         for raw, expected_name, expected_value in cases:
-            node = LeafNode.parse(raw, self.parser)
+            node = next(iter(self.loader.loads(raw)))
             self.assertEqual(expected_name, node.name,
                              "Expected node('%s').name to be %s, got %s" %
                              (repr(raw), expected_name, node.name))
@@ -160,17 +160,17 @@ class WLoaderTestCaseRead(unittest.TestCase):
             ('  include path', 'include', 'path'),
             ('\ninclude path', 'include', 'path'),
         ]
-        self._test_item_cases(cases, 'include', self.parser)
+        self._test_item_cases(cases, 'include')
 
     def testDumpUnicodeSupport(self):
         text = "\n value is 三"
-        node = LeafNode.parse(text, self.parser)
+        node = next(iter(self.loader.loads(text)))
         dump = node.dump()
         self.assertTrue(isinstance(dump, six.text_type))
         self.assertEquals(dump, text)
 
     def testStrUnicodeBuiltIns(self):
-        node = LeafNode.parse("\n option value", self.parser)
+        node = next(iter(self.loader.loads("\n option value")))
         self.assertTrue(isinstance(str(node), str))
         self.assertTrue(isinstance(node.__unicode__(), six.text_type))
         self.assertEquals(
@@ -186,13 +186,14 @@ class WLoaderTestCaseRead(unittest.TestCase):
             ('a b\n<b>\n</b>  \n', ('a b', '\n<b>\n</b>')),
         ]
         for raw, expected in cases:
-            node = ListNode.parse(raw, self.parser)
+            node = self.loader.loads(raw)
             self.assertEqual(len(node), len(expected))
             for got, expected in zip(node, expected):
                 self.assertEqual(got.dump(), expected)
             self.assertEqual(raw, node.dump())
 
     def testMalformedContents(self):
+        from apacheconfig.wloader import ListNode
         cases = [
             (["block", ("b",), [], "b"], "Wrong typestring."),
             (["statement", "option", " ", "value"], "Wrong typestring."),
@@ -201,7 +202,7 @@ class WLoaderTestCaseRead(unittest.TestCase):
         ]
         for case in cases:
             self.assertRaises(ApacheConfigError, ListNode, case[0],
-                              self.parser)
+                              None)
 
     def testModifyListIndexError(self):
         cases = [
@@ -213,7 +214,7 @@ class WLoaderTestCaseRead(unittest.TestCase):
             ('\n', "add", 1),
         ]
         for raw, fn, index in cases:
-            node = ListNode.parse(raw, self.parser)
+            node = self.loader.loads(raw)
             self.assertEqual(raw, node.dump())
             if fn == "add":
                 self.assertRaises(IndexError, node.add, index, " # comment")
@@ -221,12 +222,13 @@ class WLoaderTestCaseRead(unittest.TestCase):
                 self.assertRaises(IndexError, node.remove, index)
 
     def testListAddParsingError(self):
-        node = ListNode.parse("a b\nc d", self.parser)
+        node = self.loader.loads("a b\nc d")
         cases = ["a b\nc d", ""]
         for case in cases:
             self.assertRaises(ApacheConfigError, node.add, 0, case)
 
     def testMalformedBlocks(self):
+        from apacheconfig.wloader import BlockNode
         cases = [
             (["contents", []], "Wrong typestring."),
             (["statement", "option", " ", "value"], "Wrong typestring."),
@@ -235,9 +237,10 @@ class WLoaderTestCaseRead(unittest.TestCase):
         ]
         for case in cases:
             self.assertRaises(ApacheConfigError, BlockNode, case[0],
-                              self.parser)
+                              None)
 
     def testMalformedItem(self):
+        from apacheconfig.wloader import LeafNode
         cases = [
             (["contents", []], "Wrong typestring."),
             (["block", ("b",), [], "b"], "Wrong typestring."),
@@ -256,12 +259,12 @@ class WLoaderTestCaseRead(unittest.TestCase):
             ('\n<b>\n</b>', None),
         ]
         for (raw, value) in cases:
-            node = BlockNode.parse(raw, self.parser)
+            node = next(iter(self.loader.loads(raw)))
             self.assertEqual("b", node.tag)
             self.assertEqual(value, node.arguments)
             self.assertEqual(raw, node.dump())
 
-    def testLoadWholeConfig(self):
+    def testLoadWholeConfigFromFile(self):
         text = """\
 
 # a
@@ -275,6 +278,13 @@ a b
 c "d d"
 </a>
 # a
+
+
 """
-        node = ListNode.parse(text, self.parser)
+        t = tempfile.mkdtemp()
+        filepath = os.path.join(t, "config")
+        with open(filepath, "w") as f:
+            f.write(text)
+        node = self.loader.load(filepath)
         self.assertEqual(text, node.dump())
+        shutil.rmtree(t)


### PR DESCRIPTION
Fixes #49.

As we mentioned a while ago, I moved this decision out to a separate PR. Good news is that this will hopefully be the final one to reach a baseline of functionality and close #49 :)

Tried to match the interface for `make_loader`; Right now the `WritableLoader` object is pretty bare bones, but can be extended to do other things in the future, like the regular `Loader` object.

Also rolled in a couple of very small fixes; let me know if you prefer these in a separate PR.

Let me know what you think!