### PR TITLE
Forward error code in `tests/__main__.py` and fix tests

### DIFF
--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -363,7 +363,7 @@ def make_lexer(**options):
     if options.get('nostripvalues'):
         lexer_class = NoStripLexer
 
-    lexer_class = type(six.binary_type('ApacheConfigLexer'),
+    lexer_class = type(str('ApacheConfigLexer'),
                        (lexer_class, HashCommentsLexer),
                        {'tokens': lexer_class.tokens +
                         HashCommentsLexer.tokens,
@@ -372,7 +372,7 @@ def make_lexer(**options):
                         'options': options})
 
     if options.get('ccomments', True):
-        lexer_class = type(six.binary_type('ApacheConfigLexer'),
+        lexer_class = type(str('ApacheConfigLexer'),
                            (lexer_class, CStyleCommentsLexer),
                            {'tokens': lexer_class.tokens +
                             CStyleCommentsLexer.tokens,
@@ -381,7 +381,7 @@ def make_lexer(**options):
                             'options': options})
 
     if options.get('useapacheinclude', True):
-        lexer_class = type(six.binary_type('ApacheConfigLexer'),
+        lexer_class = type(str('ApacheConfigLexer'),
                            (lexer_class, ApacheIncludesLexer),
                            {'tokens': lexer_class.tokens +
                             ApacheIncludesLexer.tokens,

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -232,20 +232,20 @@ def make_parser(**options):
     parser_class = BaseApacheConfigParser
 
     if options.get('ccomments', True):
-        parser_class = type(six.binary_type('ApacheConfigParser'),
+        parser_class = type(str('ApacheConfigParser'),
                             (parser_class, CStyleCommentsParser),
                             {'options': options})
     else:
-        parser_class = type(six.binary_type('ApacheConfigParser'),
+        parser_class = type(str('ApacheConfigParser'),
                             (parser_class, HashCommentsParser),
                             {'options': options})
 
     if options.get('useapacheinclude', True):
-        parser_class = type(six.binary_type('ApacheConfigParser'),
+        parser_class = type(str('ApacheConfigParser'),
                             (parser_class, ApacheIncludesParser),
                             {'options': options})
     else:
-        parser_class = type(six.binary_type('ApacheConfigParser'),
+        parser_class = type(str('ApacheConfigParser'),
                             (parser_class, IncludesParser),
                             {'options': options})
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -18,7 +18,4 @@ suite = unittest.TestLoader().loadTestsFromNames(
 
 if __name__ == '__main__':
     result = unittest.TextTestRunner(verbosity=2).run(suite)
-    if result.wasSuccessful():
-        exit(0)
-    else:
-        exit(1)
+    exit(not result.wasSuccessful())

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -18,7 +18,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
 
 if __name__ == '__main__':
     result = unittest.TextTestRunner(verbosity=2).run(suite)
-    if result.wasSucccessful():
+    if result.wasSuccessful():
         exit(0)
     else:
         exit(1)

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -17,4 +17,8 @@ suite = unittest.TestLoader().loadTestsFromNames(
 
 
 if __name__ == '__main__':
-    unittest.TextTestRunner(verbosity=2).run(suite)
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    if result.wasSucccessful():
+        exit(0)
+    else:
+        exit(1)

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -82,9 +82,10 @@ a = b
 <a block>
   a = b
 </a>
-a "b b"
+a b
 <a a block>
 b = 三
+c "d d"
 </a>
 # a
 """
@@ -96,10 +97,11 @@ a b
     a b
   </block>
 </a>
-a "b b"
+a b
 <a>
   <a block>
     b 三
+    c "d d"
   </a block>
 </a>
 """

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -78,12 +78,11 @@ c "d d"
 
 # a
 a = b
-c "d d"
 
 <a block>
   a = b
 </a>
-a b
+a "b b"
 <a a block>
 b = 三
 </a>
@@ -97,13 +96,12 @@ a b
     a b
   </block>
 </a>
-a b
+a "b b"
 <a>
   <a block>
     b 三
   </a block>
 </a>
-c "d d"
 """
 
         ApacheConfigLexer = make_lexer()

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -84,8 +84,8 @@ a = b
 </a>
 a b
 <a a block>
-b = 三
 c "d d"
+b = 三
 </a>
 # a
 """
@@ -100,8 +100,8 @@ a b
 a b
 <a>
   <a block>
-    b 三
     c "d d"
+    b 三
   </a block>
 </a>
 """
@@ -114,7 +114,16 @@ a b
 
         config = loader.loads(text)
         gen_text = loader.dumps(config)
-        self.assertEqual(expect_text, gen_text)
+
+        try:
+            self.assertEqual(expect_text, gen_text)
+        except:
+            # Account for non-deterministic ordering of dict items;
+            # swap lines `b 三` and `c "d d"`
+            lines = expect_text.split('\n')
+            lines[9], lines[10] = lines[10], lines[9]
+            expect_text = "\n".join(lines)
+            self.assertEqual(expect_text, gen_text)
 
         # Testing dump(filepath, config)
         tmpd = tempfile.mkdtemp()

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -78,13 +78,13 @@ c "d d"
 
 # a
 a = b
+c "d d"
 
 <a block>
   a = b
 </a>
 a b
 <a a block>
-c "d d"
 b = 三
 </a>
 # a
@@ -100,10 +100,10 @@ a b
 a b
 <a>
   <a block>
-    c "d d"
     b 三
   </a block>
 </a>
+c "d d"
 """
 
         ApacheConfigLexer = make_lexer()

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -117,7 +117,7 @@ a b
 
         try:
             self.assertEqual(expect_text, gen_text)
-        except:
+        except AssertionError:
             # Account for non-deterministic ordering of dict items;
             # swap lines `b 三` and `c "d d"`
             lines = expect_text.split('\n')

--- a/tests/unit/test_wloader.py
+++ b/tests/unit/test_wloader.py
@@ -171,6 +171,7 @@ class WLoaderTestCaseRead(unittest.TestCase):
         node = next(iter(self.loader.loads("\n option value")))
         self.assertTrue(isinstance(str(node), str))
         self.assertTrue(isinstance(node.__unicode__(), six.text_type))
+        # Make test compatible with both u'string' and 'string'
         node_str = six.text_type(node).replace("u'", "'")
         self.assertEqual(
             "LeafNode(['statement', 'option', ' ', 'value'])",

--- a/tests/unit/test_wloader.py
+++ b/tests/unit/test_wloader.py
@@ -171,11 +171,11 @@ class WLoaderTestCaseRead(unittest.TestCase):
         node = next(iter(self.loader.loads("\n option value")))
         self.assertTrue(isinstance(str(node), str))
         self.assertTrue(isinstance(node.__unicode__(), six.text_type))
-        # Make test compatible with both u'string' and 'string'
-        node_str = six.text_type(node).replace("u'", "'")
+        if six.PY2:
+            # Make test compatible with both u'string' and 'string'
+            node_str = six.text_type(node).replace("u'", "'")
         self.assertEqual(
-            "LeafNode(['statement', 'option', ' ', 'value'])",
-            node_str)
+            "LeafNode(['statement', 'option', ' ', 'value'])", node_str)
 
     def testLoadContents(self):
         cases = [

--- a/tests/unit/test_wloader.py
+++ b/tests/unit/test_wloader.py
@@ -165,15 +165,16 @@ class WLoaderTestCaseRead(unittest.TestCase):
         node = next(iter(self.loader.loads(text)))
         dump = node.dump()
         self.assertTrue(isinstance(dump, six.text_type))
-        self.assertEquals(dump, text)
+        self.assertEqual(dump, text)
 
     def testStrUnicodeBuiltIns(self):
         node = next(iter(self.loader.loads("\n option value")))
         self.assertTrue(isinstance(str(node), str))
         self.assertTrue(isinstance(node.__unicode__(), six.text_type))
-        self.assertEquals(
-            "LeafNode([u'statement', u'option', u' ', u'value'])",
-            six.text_type(node))
+        node_str = six.text_type(node).replace("u'", "'")
+        self.assertEqual(
+            "LeafNode(['statement', 'option', ' ', 'value'])",
+            node_str)
 
     def testLoadContents(self):
         cases = [


### PR DESCRIPTION
After doing some more testing, it turns out some Python3 tests were silently failing! Fixed `tests/__main__.py` to forward exit codes correctly.

Lastly, there is also a deprecation warning we're getting sometimes from `lex`, which I'll investigate in a separate issue: #96 

This might want to go out in a point release fix (0.3.1?) once we land it!