### PR TITLE
Sort import orders.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,14 @@ matrix:
     dist: trusty
     python: 'pypy3'
 install:
-  - if [ "$LINT" == "true" ]; then pip install flake8; fi
+  - if [ "$LINT" == "true" ]; then pip install flake8 isort; fi
   - pip install codecov
   - pip install -r requirements.txt -r test-requirements.txt
   - if [ "$TEST_OLDEST_DEPS" == "true" ]; then pip install -r oldest-requirements.txt; fi
   - pip install -e .
 script:
   - if [ "$LINT" == "true" ]; then flake8 ./apacheconfig ./tests ./setup.py; fi
+  - if [ "$LINT" == "true" ]; then isort --check-only -rc apacheconfig tests setup.py; fi
   - if [ "$DOCS" == "true" ]; then cd ./docs && make html && cd -; fi
   - PYTHONPATH=.:$PYTHONPATH python tests/__main__.py
 after_success:

--- a/apacheconfig/__init__.py
+++ b/apacheconfig/__init__.py
@@ -3,12 +3,12 @@ __version__ = '0.3.1'
 
 from contextlib import contextmanager
 
-from apacheconfig.lexer import make_lexer
-from apacheconfig.parser import make_parser
-from apacheconfig.loader import ApacheConfigLoader
-from apacheconfig.wloader import ApacheConfigWritableLoader
-from apacheconfig.error import ApacheConfigError
 from apacheconfig import flavors  # noqa: F401
+from apacheconfig.error import ApacheConfigError
+from apacheconfig.lexer import make_lexer
+from apacheconfig.loader import ApacheConfigLoader
+from apacheconfig.parser import make_parser
+from apacheconfig.wloader import ApacheConfigWritableLoader
 
 
 @contextmanager

--- a/apacheconfig/apacheconfigtool.py
+++ b/apacheconfig/apacheconfigtool.py
@@ -5,12 +5,11 @@
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
 import argparse
-import sys
-import os
 import json
+import os
+import sys
 
-from apacheconfig import make_loader, ApacheConfigError
-from apacheconfig import __version__
+from apacheconfig import ApacheConfigError, __version__, make_loader
 
 
 def main():

--- a/apacheconfig/lexer.py
+++ b/apacheconfig/lexer.py
@@ -8,8 +8,9 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import six
+
 import ply.lex as lex
+import six
 
 from apacheconfig.error import ApacheConfigError
 

--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -9,9 +9,10 @@ from __future__ import unicode_literals
 import glob
 import io
 import logging
-import re
 import os
+import re
 import tempfile
+
 import six
 
 from apacheconfig import error

--- a/apacheconfig/parser.py
+++ b/apacheconfig/parser.py
@@ -7,6 +7,7 @@
 from __future__ import unicode_literals
 
 import logging
+
 import ply.yacc as yacc
 import six
 

--- a/apacheconfig/reader.py
+++ b/apacheconfig/reader.py
@@ -1,5 +1,5 @@
-import os
 import io
+import os
 
 
 class LocalHostReader(object):

--- a/apacheconfig/wloader.py
+++ b/apacheconfig/wloader.py
@@ -7,11 +7,11 @@
 from __future__ import unicode_literals
 
 import abc
+
 import six
 
-from apacheconfig.reader import LocalHostReader
-
 from apacheconfig import error
+from apacheconfig.reader import LocalHostReader
 
 
 class ApacheConfigWritableLoader(object):

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ universal = 1
 
 [metadata]
 license_file = LICENSE.rst
+
+[isort]
+known_first_party = apacheconfig

--- a/tests/integration/test_perl_samples.py
+++ b/tests/integration/test_perl_samples.py
@@ -10,8 +10,7 @@ from __future__ import unicode_literals
 import os
 import sys
 
-from apacheconfig import ApacheConfigError
-from apacheconfig import make_loader
+from apacheconfig import ApacheConfigError, make_loader
 
 try:
     import unittest2 as unittest

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -9,8 +9,7 @@ from __future__ import unicode_literals
 
 import sys
 
-from apacheconfig import ApacheConfigError
-from apacheconfig import make_lexer
+from apacheconfig import ApacheConfigError, make_lexer
 
 try:
     import unittest2 as unittest

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -13,11 +13,8 @@ import shutil
 import sys
 import tempfile
 
-from apacheconfig import ApacheConfigError
-from apacheconfig import ApacheConfigLoader
-from apacheconfig import make_lexer
-from apacheconfig import make_loader
-from apacheconfig import make_parser
+from apacheconfig import (ApacheConfigError, ApacheConfigLoader, make_lexer,
+                          make_loader, make_parser)
 
 try:
     import unittest2 as unittest

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -9,8 +9,7 @@ from __future__ import unicode_literals
 
 import sys
 
-from apacheconfig import make_lexer
-from apacheconfig import make_parser
+from apacheconfig import make_lexer, make_parser
 
 try:
     import unittest2 as unittest

--- a/tests/unit/test_parser_whitespace.py
+++ b/tests/unit/test_parser_whitespace.py
@@ -4,10 +4,9 @@
 # Copyright (c) 2018-2019, Ilya Etingof <etingof@gmail.com>
 # License: https://github.com/etingof/apacheconfig/LICENSE.rst
 #
-from apacheconfig import make_lexer
-from apacheconfig import make_parser
-
 import sys
+
+from apacheconfig import make_lexer, make_parser
 
 try:
     import unittest2 as unittest

--- a/tests/unit/test_wloader.py
+++ b/tests/unit/test_wloader.py
@@ -7,22 +7,21 @@
 #
 from __future__ import unicode_literals
 
+import os
+import shutil
+import sys
+import tempfile
+
 import six
+
+from apacheconfig import flavors, make_loader
+from apacheconfig.error import ApacheConfigError
 
 try:
     import unittest2 as unittest
 
 except ImportError:
     import unittest
-
-import os
-import shutil
-import sys
-import tempfile
-
-from apacheconfig import flavors
-from apacheconfig import make_loader
-from apacheconfig.error import ApacheConfigError
 
 
 class WLoaderTestCaseWrite(unittest.TestCase):


### PR DESCRIPTION
Sorted imports using [isort](https://pypi.python.org/pypi/isort/) and added an isort check to the Travis lint run.

Let me know if you have thoughts on the configuration.

Fixes #91 