### PR TITLE
Do not quote option value if value contains spaces

### DIFF
--- a/apacheconfig/loader.py
+++ b/apacheconfig/loader.py
@@ -416,7 +416,7 @@ class ApacheConfigLoader(object):
 
         for key, val in obj.items():
             if isinstance(val, six.text_type):
-                if val.isalnum():
+                if val.isalnum() or ' ' in val:
                     text += '%s%s %s\n' % (spacing, key, val)
                 else:
                     text += '%s%s "%s"\n' % (spacing, key, val)


### PR DESCRIPTION
Currently, any non-alphanumeric text value is quoted. This can be a problem for multi-word values split by spaces, such as `SuexecUserGroup $user $group`. Surrounding its value by double quotes would result in an invalid configuration.

Checking if the value contains spaces 'fixes' this behaviour.